### PR TITLE
feat: Generate and expose OpenAPI schema using drf-spectacular

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -75,6 +75,7 @@ in
       cvss
       freezegun
       django-model-utils
+      drf-spectacular
     ];
 
     passthru.PLAYWRIGHT_BROWSERS_PATH = final.playwright-driver.browsers;

--- a/src/README.md
+++ b/src/README.md
@@ -2,8 +2,10 @@
 
 The Nix security tracker is implemented in the Django framework.
 
-In addition to the `manage.py` administration utility, there are three top-level directories here:
+In addition to the `manage.py` administration utility, there are top-level directories here:
 
 - [`project`](./project/): Configuration for the web server running the project.
+- [`api`](./api/): Our REST API powered by Django REST framework (OpenAPI schema served on `/api/schema`)
+- [`feeds`](./feeds/): Atom feeds
 - [`shared`](./shared/): Utilities and models consumed by the other components.
 - [`webview`](./webview/): The views which comprise the web frontend.

--- a/src/api/urls.py
+++ b/src/api/urls.py
@@ -1,4 +1,5 @@
 from django.urls import include, path
+from drf_spectacular.views import SpectacularAPIView
 from rest_framework import routers
 
 from api.issues.views import NixpkgsIssueViewSet
@@ -12,4 +13,5 @@ v1_router.register("subscriptions", SubscriptionsViewSet)
 
 urlpatterns = [
     path("v1/", include(v1_router.urls)),
+    path("schema/", SpectacularAPIView.as_view(), name="schema"),
 ]

--- a/src/project/settings.py
+++ b/src/project/settings.py
@@ -373,6 +373,7 @@ INSTALLED_APPS = [
     "shared",
     "api",
     "webview",
+    "drf_spectacular",
 ]
 
 MIDDLEWARE = [
@@ -441,6 +442,14 @@ AUTHENTICATION_BACKENDS = [
 REST_FRAMEWORK = {
     "DEFAULT_FILTER_BACKENDS": ["django_filters.rest_framework.DjangoFilterBackend"],
     "EXCEPTION_HANDLER": "api.exceptions.custom_exception_handler",
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+}
+
+# drf-spectacular (openapi generation) settings
+SPECTACULAR_SETTINGS = {
+    "TITLE": "Nixpkgs security tracker API",
+    "VERSION": "1.0.0",
+    "SERVE_INCLUDE_SCHEMA": False,
 }
 
 SITE_ID = 1


### PR DESCRIPTION
This adds drf-spectacular with basic configuration (starter from official documentation) to sec tracker to generate an OpenAPI spec from our API views. 

This introduces the `spectacular` management command and exposes the openapi schema on `/api/schema`

Here is what the current schema looks like. This PR is not about improving it. This may be done later through annotations.


```yaml
openapi: 3.0.3
info:
  title: Nixpkgs security tracker API
  version: 1.0.0
paths:
  /api/v1/issues:
    get:
      operationId: issues_list
      parameters:
      - in: query
        name: cve
        schema:
          type: array
          items:
            type: string
        description: Multiple values may be separated by commas.
        explode: false
        style: form
      tags:
      - issues
      security:
      - cookieAuth: []
      - basicAuth: []
      - {}
      responses:
        '200':
          description: No response body
  /api/v1/issues/{id}:
    get:
      operationId: issues_retrieve
      parameters:
      - in: path
        name: id
        schema:
          type: integer
        description: A unique integer value identifying this nixpkgs issue.
        required: true
      tags:
      - issues
      security:
      - cookieAuth: []
      - basicAuth: []
      - {}
      responses:
        '200':
          description: No response body
  /api/v1/issues/by-code/{code}:
    get:
      operationId: issues_by_code_retrieve
      parameters:
      - in: path
        name: code
        schema:
          type: string
          pattern: ^NIXPKGS-[0-9]{4}-[0-9]{4,19}$
        required: true
      tags:
      - issues
      security:
      - cookieAuth: []
      - basicAuth: []
      - {}
      responses:
        '200':
          description: No response body
  /api/v1/subscriptions/auto-subscribe-to-maintained-packages:
    get:
      operationId: subscriptions_auto_subscribe_to_maintained_packages_retrieve
      tags:
      - subscriptions
      security:
      - cookieAuth: []
      - basicAuth: []
      responses:
        '200':
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/AutoSubscribe'
          description: ''
    put:
      operationId: subscriptions_auto_subscribe_to_maintained_packages_update
      tags:
      - subscriptions
      requestBody:
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/AutoSubscribe'
          application/x-www-form-urlencoded:
            schema:
              $ref: '#/components/schemas/AutoSubscribe'
          multipart/form-data:
            schema:
              $ref: '#/components/schemas/AutoSubscribe'
        required: true
      security:
      - cookieAuth: []
      - basicAuth: []
      responses:
        '200':
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/AutoSubscribe'
          description: ''
  /api/v1/suggestions/{id}/change_status:
    post:
      operationId: suggestions_change_status_create
      parameters:
      - in: path
        name: id
        schema:
          type: integer
        description: A unique integer value identifying this cve derivation cluster
          proposal.
        required: true
      tags:
      - suggestions
      requestBody:
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/Status'
          application/x-www-form-urlencoded:
            schema:
              $ref: '#/components/schemas/Status'
          multipart/form-data:
            schema:
              $ref: '#/components/schemas/Status'
        required: true
      security:
      - cookieAuth: []
      - basicAuth: []
      responses:
        '200':
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Status'
          description: ''
  /api/v1/suggestions/{id}/status:
    get:
      operationId: suggestions_status_retrieve
      parameters:
      - in: path
        name: id
        schema:
          type: integer
        description: A unique integer value identifying this cve derivation cluster
          proposal.
        required: true
      tags:
      - suggestions
      security:
      - cookieAuth: []
      - basicAuth: []
      - {}
      responses:
        '200':
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Status'
          description: ''
components:
  schemas:
    '':
      type: object
      properties:
        code:
          type: string
          maxLength: 32
        cve:
          type: string
          nullable: true
          readOnly: true
        status:
          type: string
      required:
      - code
      - cve
      - status
    AutoSubscribe:
      type: object
      properties:
        enabled:
          type: boolean
      required:
      - enabled
    BlankEnum:
      enum:
      - ''
    NullEnum:
      enum:
      - null
    RejectionReasonEnum:
      enum:
      - exclusively_hosted_service
      - not_in_nixpkgs
      - hardware_only_cpe
      type: string
      description: |-
        * `exclusively_hosted_service` - exclusively hosted service
        * `not_in_nixpkgs` - not in Nixpkgs
        * `hardware_only_cpe` - hardware only
    Status:
      type: object
      properties:
        status:
          $ref: '#/components/schemas/StatusEnum'
        rejection_reason:
          nullable: true
          description: |-
            Reason for rejection (automatic or manual)

            * `exclusively_hosted_service` - exclusively hosted service
            * `not_in_nixpkgs` - not in Nixpkgs
            * `hardware_only_cpe` - hardware only
          oneOf:
          - $ref: '#/components/schemas/RejectionReasonEnum'
          - $ref: '#/components/schemas/BlankEnum'
          - $ref: '#/components/schemas/NullEnum'
        comment:
          type: string
          nullable: true
          description: Optional free text comment for additional notes, context, dismissal
            reason
          maxLength: 1000
      required:
      - status
    StatusEnum:
      enum:
      - pending
      - rejected
      - accepted
      - published
      type: string
      description: |-
        * `pending` - pending
        * `rejected` - rejected
        * `accepted` - accepted
        * `published` - published
  securitySchemes:
    basicAuth:
      type: http
      scheme: basic
    cookieAuth:
      type: apiKey
      in: cookie
      name: sessionid
```