### PR TITLE
feat: add per-channel evaluation status to Grafana

### DIFF
--- a/contrib/grafana-dashboard.json
+++ b/contrib/grafana-dashboard.json
@@ -28,6 +28,12 @@
       "id": "stat",
       "name": "Stat",
       "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
     }
   ],
   "annotations": {
@@ -800,12 +806,278 @@
       "type": "stat"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Latest and latest-successful Nixpkgs evaluation per tracked channel",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Channel"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 200
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Latest state"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 120
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "text",
+                        "index": 0,
+                        "text": "—"
+                      },
+                      "1": {
+                        "color": "yellow",
+                        "index": 1,
+                        "text": "Waiting"
+                      },
+                      "2": {
+                        "color": "blue",
+                        "index": 2,
+                        "text": "In progress"
+                      },
+                      "3": {
+                        "color": "green",
+                        "index": 3,
+                        "text": "Completed"
+                      },
+                      "4": {
+                        "color": "orange",
+                        "index": 4,
+                        "text": "Crashed"
+                      },
+                      "5": {
+                        "color": "red",
+                        "index": 5,
+                        "text": "Failed"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Latest updated"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "dateTimeAsIso"
+              },
+              {
+                "id": "custom.align",
+                "value": "right"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Latest successful updated"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "dateTimeAsIso"
+              },
+              {
+                "id": "custom.align",
+                "value": "right"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Latest elapsed"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              },
+              {
+                "id": "custom.align",
+                "value": "right"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Latest successful at HEAD"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "text": "No"
+                      },
+                      "1": {
+                        "text": "Yes"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "id": 11,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Channel"
+          }
+        ]
+      },
+      "pluginVersion": "12.1.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sql_channel_evaluation_status{sql_job=\"sectracker\", instance=\"$Instance\"}",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Channel evaluation status",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "keepLabels": [
+              "channel",
+              "col"
+            ],
+            "mode": "columns",
+            "valueLabel": "col"
+          }
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "Value",
+                "channel",
+                "col"
+              ]
+            }
+          }
+        },
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "col",
+            "emptyValue": "null",
+            "rowField": "channel",
+            "valueField": "Value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "channel\\col": 0,
+              "latest_elapsed": 3,
+              "latest_state": 1,
+              "latest_successful_at_head": 5,
+              "latest_successful_updated": 4,
+              "latest_updated": 2
+            },
+            "renameByName": {
+              "channel\\col": "Channel",
+              "latest_elapsed": "Latest elapsed",
+              "latest_state": "Latest state",
+              "latest_successful_at_head": "Latest successful at HEAD",
+              "latest_successful_updated": "Latest successful updated",
+              "latest_updated": "Latest updated"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 11
+        "y": 21
       },
       "id": 5,
       "panels": [],
@@ -844,7 +1116,7 @@
         "h": 4,
         "w": 4,
         "x": 0,
-        "y": 12
+        "y": 22
       },
       "id": 9,
       "options": {

--- a/infra/sql-exporter-queries.nix
+++ b/infra/sql-exporter-queries.nix
@@ -49,4 +49,61 @@
     query = "select count(*) from shared_cvederivationclusterproposal where status='published';";
     values = [ "count" ];
   };
+  channel_evaluation_status = {
+    help = "Per-channel latest and latest-successful Nix evaluation status";
+    labels = [
+      "channel"
+    ];
+    values = [
+      "latest_state"
+      "latest_updated"
+      "latest_elapsed"
+      "latest_successful_updated"
+      "latest_successful_at_head"
+    ];
+    query = "
+            WITH latest AS (
+              SELECT DISTINCT ON (channel_id)
+                channel_id, state, commit_sha1, updated_at, elapsed
+              FROM shared_nixevaluation
+              ORDER BY channel_id, updated_at DESC
+            ),
+            latest_successful AS (
+              SELECT DISTINCT ON (channel_id)
+                channel_id, commit_sha1, updated_at
+              FROM shared_nixevaluation
+              WHERE state = 'COMPLETED'
+              ORDER BY channel_id, updated_at DESC
+            )
+            SELECT
+              c.channel_branch::text AS channel,
+              CASE l.state
+                WHEN 'WAITING' THEN 1
+                WHEN 'IN_PROGRESS' THEN 2
+                WHEN 'COMPLETED' THEN 3
+                WHEN 'CRASHED' THEN 4
+                WHEN 'FAILED' THEN 5
+                ELSE 0
+              END::float AS latest_state,
+              CASE
+                WHEN l.updated_at IS NULL THEN NULL
+                ELSE extract(epoch FROM l.updated_at) * 1000
+              END::float AS latest_updated,
+              CASE
+                WHEN l.state IS NULL OR l.state = '' THEN NULL
+                WHEN l.state IN ('COMPLETED', 'CRASHED', 'FAILED') THEN COALESCE(l.elapsed, 0)
+                ELSE EXTRACT(EPOCH FROM (now() - l.updated_at))::float
+              END AS latest_elapsed,
+              CASE
+                WHEN s.updated_at IS NULL THEN NULL
+                ELSE extract(epoch FROM s.updated_at) * 1000
+              END::float AS latest_successful_updated,
+              CASE WHEN s.commit_sha1 IS NOT NULL AND s.commit_sha1 = c.head_sha1_commit THEN 1 ELSE 0 END::float AS latest_successful_at_head
+            FROM shared_nixchannel c
+            LEFT JOIN latest l ON l.channel_id = c.channel_branch
+            LEFT JOIN latest_successful s ON s.channel_id = c.channel_branch
+            WHERE c.state IN ('deprecated', 'beta', 'stable', 'rolling')
+            ORDER BY c.channel_branch
+          ";
+  };
 }


### PR DESCRIPTION
This PR adds observability for per-channel Nix evaluation health 
* SQL exporter query `channel_evaluation_status` in `infra/common.nix` exports `sql_channel_evaluation_status` with per-channel labels (channel, HEAD, latest state, commits) and timestamps
* Grafana table panel shows latest eval state and latest successful eval for each tracked channel

Table columns
| Column | Source |
| --- | --- |
| Channel | `channel_branch` |
| HEAD | `head_sha1_commit` |
| Latest state | raw enum (`WAITING`, `IN_PROGRESS`, `COMPLETED`, `CRASHED`, `FAILED`) |
| Latest commit | latest eval `commit_sha1` |
| Latest updated | latest eval `updated_at` |
| Latest elapsed | latest eval `elapsed` |
| Latest successful commit | newest `COMPLETED` eval |
| Latest successful updated | newest `COMPLETED` eval `updated_at` |

Channels filtered to DEPRECATED, BETA, STABLE, UNSTABLE (same as ADMISSIBLE_CHANNEL_STATES today).

Future work:
* pghistory on `NixEvaluation` state changes for waiting duration
* Alerts once thresholds decided
