### PR TITLE
GET /notifications

### DIFF
--- a/src/api/notifications/views.py
+++ b/src/api/notifications/views.py
@@ -1,0 +1,132 @@
+from enum import StrEnum
+from typing import Any
+
+from django.db.models import QuerySet
+from drf_spectacular.utils import extend_schema, extend_schema_field
+from rest_framework import serializers, viewsets
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from api.suggestions.serializers import SuggestionPackageSerializer
+from shared.cache_suggestions import CachedSuggestion
+from webview.models import Notification, SuggestionNotification, TextNotification
+
+
+class NotificationType(StrEnum):
+    TEXT = "text"
+    SUGGESTION = "suggestion"
+
+
+class NotificationSerializer(serializers.ModelSerializer):
+    is_obsolete = serializers.SerializerMethodField()
+    message = serializers.SerializerMethodField()
+    matching_maintained_packages = serializers.SerializerMethodField()
+    matching_subscribed_packages = serializers.SerializerMethodField()
+    suggestion_id = serializers.SerializerMethodField()
+    title = serializers.SerializerMethodField()
+    type = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Notification
+        fields = [
+            "created_at",
+            "id",
+            "is_obsolete",
+            "is_read",
+            "message",
+            "matching_maintained_packages",
+            "matching_subscribed_packages",
+            "suggestion_id",
+            "title",
+            "type",
+        ]
+
+    def get_is_obsolete(self, notif: Notification) -> bool:
+        if isinstance(notif, TextNotification):
+            return False
+        return not (
+            self.get_matching_maintained_packages(notif)
+            or self.get_matching_subscribed_packages(notif)
+        )
+
+    def get_message(self, notif: Notification) -> str | None:
+        if isinstance(notif, TextNotification):
+            return notif.message
+        return None
+
+    @extend_schema_field(serializers.DictField(child=SuggestionPackageSerializer()))
+    def get_matching_maintained_packages(
+        self, notif: Notification
+    ) -> dict[str, Any] | None:
+        username = self.context["request"].user.username
+        if isinstance(notif, SuggestionNotification):
+            cached = CachedSuggestion.model_validate(notif.suggestion.cached.payload)
+            return {
+                pname: SuggestionPackageSerializer(pkg).data
+                for pname, pkg in cached.packages.items()
+                if any(m.github == username for m in pkg.maintainers)
+            }
+        return None
+
+    @extend_schema_field(serializers.DictField(child=SuggestionPackageSerializer()))
+    def get_matching_subscribed_packages(
+        self, notif: Notification
+    ) -> dict[str, Any] | None:
+        if isinstance(notif, SuggestionNotification):
+            cached = CachedSuggestion.model_validate(notif.suggestion.cached.payload)
+            subscribed_attrs = set(
+                self.context["request"].user.profile.package_subscriptions
+            )
+            return {
+                attr: SuggestionPackageSerializer(cached.packages[attr]).data
+                for attr in cached.packages
+                if attr in subscribed_attrs
+            }
+        return None
+
+    def get_suggestion_id(self, notif: Notification) -> int | None:
+        if isinstance(notif, SuggestionNotification):
+            return notif.suggestion_id
+        return None
+
+    def get_title(self, notif: Notification) -> str:
+        return notif.title
+
+    def get_type(self, notif: Notification) -> NotificationType:
+        if isinstance(notif, TextNotification):
+            return NotificationType.TEXT
+        return NotificationType.SUGGESTION
+
+
+class NotificationPagination(PageNumberPagination):
+    page_size = 20
+    page_size_query_param = "per_page"
+    max_page_size = 100
+
+
+class NotificationViewSet(viewsets.ReadOnlyModelViewSet):
+    permission_classes = [IsAuthenticated]
+    serializer_class = NotificationSerializer
+    pagination_class = NotificationPagination
+
+    @extend_schema(
+        operation_id="listNotifications",
+        description="List notifications for the authenticated user, ordered by most recent.",
+        responses={200: NotificationSerializer},
+    )
+    def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        return super().list(request, *args, **kwargs)
+
+    def get_queryset(  # pyright: ignore[reportIncompatibleMethodOverride]
+        self,
+    ) -> QuerySet[Notification]:
+        return (
+            Notification.objects.filter(user=self.request.user)
+            .select_related(
+                "suggestionnotification__suggestion__cve",
+            )
+            .select_subclasses()
+            .order_by("-created_at")
+        )

--- a/src/api/tests/test_notifications.py
+++ b/src/api/tests/test_notifications.py
@@ -1,0 +1,160 @@
+from collections.abc import Callable
+
+from django.contrib.auth.models import User
+from rest_framework import status
+from rest_framework.reverse import reverse
+from rest_framework.test import APIClient
+
+from api.notifications.views import NotificationType
+from webview.models import Notification
+
+
+def test_list_notifications_authenticated(
+    client: APIClient,
+    user: User,
+    make_maintainer_notification: Callable[..., list[Notification]],
+) -> None:
+    db_notifications = make_maintainer_notification(user)
+
+    url = reverse("notifications-list")
+    response = client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["count"] == 1
+
+    results = response.data["results"]
+    assert results[0]["title"] == (
+        "CVE-2025-0001 was automatically matched to packages you subscribed to"
+    )
+    assert results[0]["is_read"] is False
+    assert "id" in results[0]
+    assert "created_at" in results[0]
+    assert results[0]["type"] == NotificationType.SUGGESTION
+    assert results[0]["message"] is None
+    assert results[0]["suggestion_id"] == db_notifications[0].suggestion_id
+
+    maintained = results[0]["matching_maintained_packages"]
+    assert isinstance(maintained, dict)
+    assert len(maintained) == 1
+    pkg_data = next(iter(maintained.values()))
+    assert "channels" in pkg_data
+    assert "description" in pkg_data
+    assert "maintainers" in pkg_data
+
+    subscribed = results[0]["matching_subscribed_packages"]
+    assert isinstance(subscribed, dict)
+    assert len(subscribed) == 0
+
+    assert results[0]["is_obsolete"] is False
+
+
+def test_list_notifications_are_paginated(
+    user: User,
+    client: APIClient,
+    make_maintainer_notification: Callable[..., list[Notification]],
+) -> None:
+    make_maintainer_notification(user)
+    url = reverse("notifications-list")
+
+    response = client.get(url)
+    assert "previous" in response.data
+    assert "next" in response.data
+    assert "count" in response.data
+
+
+def test_list_notifications_excludes_other_users_notifications(
+    client: APIClient,
+    staff: User,
+    make_maintainer_notification: Callable[..., list[Notification]],
+) -> None:
+    make_maintainer_notification(staff)
+
+    url = reverse("notifications-list")
+    response = client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["count"] == 0
+
+
+def test_list_notifications_unauthenticated(
+    user: User,
+    make_maintainer_notification: Callable[..., list[Notification]],
+) -> None:
+    make_maintainer_notification(user)
+
+    client = APIClient()
+    url = reverse("notifications-list")
+    response = client.get(url)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_list_notifications_empty(
+    client: APIClient,
+) -> None:
+    url = reverse("notifications-list")
+    response = client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["count"] == 0
+
+
+def test_list_notifications_includes_text_notifications(
+    client: APIClient,
+    user: User,
+) -> None:
+    user.profile.create_text_notification("Hello", "World")
+
+    url = reverse("notifications-list")
+    response = client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["count"] == 1
+
+    api_data = response.data["results"]
+    assert api_data[0]["type"] == NotificationType.TEXT
+    assert api_data[0]["title"] == "Hello"
+    assert api_data[0]["is_read"] is False
+    assert api_data[0]["message"] == "World"
+    assert api_data[0]["suggestion_id"] is None
+    assert api_data[0]["matching_maintained_packages"] is None
+    assert api_data[0]["matching_subscribed_packages"] is None
+    assert api_data[0]["is_obsolete"] is False
+
+
+def test_list_notifications_shows_both_types(
+    client: APIClient,
+    user: User,
+    make_maintainer_notification: Callable[..., list[Notification]],
+) -> None:
+    user.profile.create_text_notification("Hello", "World")
+    db_suggestion_notifications = make_maintainer_notification(user)
+
+    url = reverse("notifications-list")
+    response = client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["count"] == 2
+
+    results = response.data["results"]
+    text_result = next(r for r in results if r["type"] == NotificationType.TEXT)
+    suggestion_result = next(
+        r for r in results if r["type"] == NotificationType.SUGGESTION
+    )
+
+    assert text_result["type"] == NotificationType.TEXT
+    assert text_result["title"] == "Hello"
+    assert text_result["message"] == "World"
+    assert text_result["suggestion_id"] is None
+
+    assert suggestion_result["type"] == NotificationType.SUGGESTION
+    assert (
+        suggestion_result["suggestion_id"]
+        == db_suggestion_notifications[0].suggestion_id
+    )
+    assert suggestion_result["message"] is None
+
+    assert isinstance(suggestion_result["matching_maintained_packages"], dict)
+    assert len(suggestion_result["matching_maintained_packages"]) == 1
+    assert isinstance(suggestion_result["matching_subscribed_packages"], dict)
+    assert len(suggestion_result["matching_subscribed_packages"]) == 0

--- a/src/api/urls.py
+++ b/src/api/urls.py
@@ -5,6 +5,7 @@ from rest_framework import routers
 from api.issues.views import IssueViewSet
 from api.matching.views import MatchingTrainingDataView
 from api.me import CurrentUserView
+from api.notifications.views import NotificationViewSet
 from api.server_info import ServerInfoView
 from api.subscriptions.views import SubscriptionsViewSet
 from api.suggestions.views import SuggestionViewSet
@@ -12,6 +13,7 @@ from api.tokens.views import TokenManagementView
 
 v1_router = routers.DefaultRouter(trailing_slash=False)
 v1_router.register(r"issues", IssueViewSet)
+v1_router.register(r"notifications", NotificationViewSet, basename="notifications")
 v1_router.register("suggestions", SuggestionViewSet)
 v1_router.register("subscriptions", SubscriptionsViewSet)
 


### PR DESCRIPTION
Related to #1024 (https://github.com/NixOS/nix-security-tracker/issues/1024#issuecomment-4804941025) 

> notifications/ seems like a pretty standalone thing to tackle @devnchill, and I can implement the front side of things after. API only

- Adds REST API endpoint for GET `notifications` 
- Tests for GET `notifications` 

