### PR TITLE
feat: ignore/restore references in API and new UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,9 +3,11 @@ import { Redirect, Route, Switch } from "wouter-preact";
 import { Footer } from "@/components/footer/Footer";
 import { Disclaimer } from "@/components/header/Disclaimer";
 import { HeaderBar } from "@/components/header/HeaderBar";
+import { Toaster } from "@/components/ui/Toaster";
 import { Home } from "@/routes/Home";
 import { SuggestionDetail } from "@/routes/SuggestionDetail";
 import { UserSettings } from "@/routes/UserSettings";
+import { toaster } from "@/utils/toaster";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -36,6 +38,7 @@ export function App() {
         </Switch>
       </main>
       <Footer />
+      <Toaster toaster={toaster} />
     </QueryClientProvider>
   );
 }

--- a/frontend/src/components/suggestions/ActivityLog.tsx
+++ b/frontend/src/components/suggestions/ActivityLog.tsx
@@ -11,8 +11,16 @@ import {
 } from "lucide-preact";
 import { useGetSuggestionActivityLog } from "@/api/generated/endpoints";
 import { type ActivityLogEntry, StatusEnum } from "@/api/generated/models";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { Spinner } from "@/components/ui/Spinner";
+import { useTick } from "@/hooks/useTick";
 import { formatTime } from "@/utils/date";
 import { SuggestionStatusIcon } from "./SuggestionStatusIcon";
+
+// Re-render frequency for relative-time displays updates
+const TICK_INTERVAL_MS = 10_000;
+// Time during which a recent update is shown as "just now"
+const JUST_NOW_MS = 5_000;
 
 type Props = {
   suggestionId: number;
@@ -158,31 +166,50 @@ function entryDescription(entry: ActivityLogEntry) {
 }
 
 function Timestamp({ iso }: { iso: string }) {
+  const date = new Date(iso);
+  const msAgo = Date.now() - date.getTime();
+
   return (
     <time datetime={iso} title={formatTime(iso)}>
-      <FormatRelativeTime value={new Date(iso)} />
+      {msAgo < JUST_NOW_MS ? (
+        "just now"
+      ) : msAgo < 60_000 ? (
+        "less than a minute ago"
+      ) : (
+        <FormatRelativeTime value={date} />
+      )}
     </time>
   );
 }
 
 export function ActivityLog({ suggestionId }: Props) {
-  const { data, isLoading } = useGetSuggestionActivityLog(suggestionId);
+  const { data, isLoading, isFetching } = useGetSuggestionActivityLog(suggestionId);
+  // Single shared tick driving re-renders for every Timestamp in this log,
+  // instead of each Timestamp instance running its own interval.
+  useTick(TICK_INTERVAL_MS);
 
-  if (isLoading || !data || data.length === 0) return null;
+  if (isLoading) {
+    return <Skeleton width="12em" height="1.2em" />;
+  }
+
+  if (!data || data.length === 0) return null;
 
   const last = data[data.length - 1];
   const summaryVerb = last.action === "create" ? "created" : "updated";
 
   return (
-    <details className="column gap-small align-end">
+    <details
+      className="column gap-small align-end"
+      data-testid={`suggestion-${suggestionId}-activity-log`}
+    >
       <summary>
-        <span className="details-closed">
-          <span className="activity-log-timestamp">
+        <span className="details-closed inline-row gap-small baseline">
+          {isFetching && <Spinner />}
+          <span>
             {summaryVerb} <Timestamp iso={last.timestamp} />
           </span>
           {last.username && (
             <>
-              {" "}
               by&nbsp;<strong>@{last.username}</strong>
             </>
           )}

--- a/frontend/src/components/suggestions/CategorizedMaintainersList.tsx
+++ b/frontend/src/components/suggestions/CategorizedMaintainersList.tsx
@@ -2,13 +2,14 @@ import type { SuggestionCategorizedMaintainers } from "@/api/generated/models";
 import { Maintainer } from "./Maintainer";
 
 type Props = {
+  suggestionId: number;
   categorizedMaintainers: SuggestionCategorizedMaintainers;
 };
 
-export function CategorizedMaintainersList({ categorizedMaintainers }: Props) {
+export function CategorizedMaintainersList({ suggestionId, categorizedMaintainers }: Props) {
   const { active, ignored, added } = categorizedMaintainers;
   return (
-    <div className="column gap">
+    <div className="column gap" data-testid={`suggestion-${suggestionId}-maintainers`}>
       <ul className="column gap-small">
         {active.map((m) => (
           <li key={m.github_id}>

--- a/frontend/src/components/suggestions/CategorizedPackagesList.tsx
+++ b/frontend/src/components/suggestions/CategorizedPackagesList.tsx
@@ -2,13 +2,14 @@ import type { SuggestionPackages } from "@/api/generated/models";
 import { PackagesList } from "./PackagesList";
 
 type Props = {
+  suggestionId: number;
   active: SuggestionPackages;
   ignored: SuggestionPackages;
 };
 
-export function CategorizedPackagesList({ active, ignored }: Props) {
+export function CategorizedPackagesList({ suggestionId, active, ignored }: Props) {
   return (
-    <div className="column gap">
+    <div className="column gap" data-testid={`suggestion-${suggestionId}-packages`}>
       <PackagesList packages={active} />
       {Object.keys(ignored).length > 0 && (
         <details className="column gap">

--- a/frontend/src/components/suggestions/CategorizedReferencesList.tsx
+++ b/frontend/src/components/suggestions/CategorizedReferencesList.tsx
@@ -3,26 +3,42 @@ import { Reference } from "./Reference";
 
 type Props = {
   categorizedReferences: SuggestionCategorizedUrlReferences;
+  suggestionId: number;
+  editable: boolean;
 };
 
-export function CategorizedReferencesList({ categorizedReferences }: Props) {
+export function CategorizedReferencesList({
+  categorizedReferences,
+  suggestionId,
+  editable,
+}: Props) {
   const { active, ignored } = categorizedReferences;
   return (
-    <div className="column gap">
+    <div className="column gap" data-testid={`suggestion-${suggestionId}-references`}>
       <ul className="column gap-small">
         {active.map((ref) => (
           <li key={ref.url}>
-            <Reference reference={ref} />
+            <Reference
+              reference={ref}
+              suggestionId={suggestionId}
+              editable={editable}
+              isIgnored={false}
+            />
           </li>
         ))}
       </ul>
       {ignored.length > 0 && (
         <details className="column gap">
-          <summary className="text-l bold text-gray">Ignored references</summary>
+          <summary className="text-l bold text-gray">Ignored references ({ignored.length})</summary>
           <ul className="column gap-small">
             {ignored.map((ref) => (
               <li key={ref.url}>
-                <Reference reference={ref} />
+                <Reference
+                  reference={ref}
+                  suggestionId={suggestionId}
+                  editable={editable}
+                  isIgnored={true}
+                />
               </li>
             ))}
           </ul>

--- a/frontend/src/components/suggestions/Reference.tsx
+++ b/frontend/src/components/suggestions/Reference.tsx
@@ -1,18 +1,43 @@
+import { Link2Icon, Link2OffIcon } from "lucide-preact";
 import type { SuggestionUrlReference } from "@/api/generated/models";
+import { useReferenceMutation } from "@/hooks/useReference";
 import { ReferenceTag } from "./ReferenceTag";
 
 type Props = {
   reference: SuggestionUrlReference;
+  suggestionId: number;
+  editable: boolean;
+  isIgnored: boolean;
 };
 
 const maxDisplayedUrlLength = 80;
 
-export function Reference({ reference }: Props) {
+export function Reference({ reference, suggestionId, editable, isIgnored }: Props) {
+  const mutation = useReferenceMutation(suggestionId);
   const label = reference.name || reference.url;
   const displayedLabel =
     label.length > maxDisplayedUrlLength ? `${label.slice(0, maxDisplayedUrlLength)}…` : label;
+
+  function handleClick() {
+    mutation.mutate({
+      id: suggestionId,
+      data: { reference_url: reference.url, ignored: !isIgnored },
+    });
+  }
+
   return (
     <div className="row gap centered">
+      {editable && (
+        <button
+          type="button"
+          className={`btn ${isIgnored ? "btn-green" : "btn-gray"} row gap-small centered`}
+          onClick={handleClick}
+          disabled={mutation.isPending}
+        >
+          {isIgnored ? <Link2Icon size="1em" /> : <Link2OffIcon size="1em" />}
+          {isIgnored ? "Restore" : "Ignore"}
+        </button>
+      )}
       <a href={reference.url} target="_blank" rel="noreferrer">
         {displayedLabel}
       </a>

--- a/frontend/src/components/suggestions/Suggestion.tsx
+++ b/frontend/src/components/suggestions/Suggestion.tsx
@@ -32,12 +32,12 @@ export function Suggestion({ suggestion }: Props) {
   } = suggestion;
 
   const { user } = useAuth();
-  const canEdit = Boolean(user?.is_committer || user?.is_admin);
+  const userCanEdit = Boolean(user?.is_committer || user?.is_admin);
 
   const nvdUrl = `https://nvd.nist.gov/vuln/detail/${encodeURIComponent(cve_id)}`;
 
   return (
-    <article className="box shadow border rounded column gap-big">
+    <article className="box shadow border rounded column gap-big" data-testid={`suggestion-${id}`}>
       {/* Status + CVE ID + title */}
       <div className="column gap">
         <SuggestionStatus status={status} rejectionReason={rejection_reason} />
@@ -62,10 +62,14 @@ export function Suggestion({ suggestion }: Props) {
       </div>
 
       {/* References */}
-      {categorized_url_references.active.length > 0 && (
+      {categorized_url_references.original.length > 0 && (
         <div className="rounded border box column gap">
           <h2 className="text-l bold text-gray">References</h2>
-          <CategorizedReferencesList categorizedReferences={categorized_url_references} />
+          <CategorizedReferencesList
+            categorizedReferences={categorized_url_references}
+            suggestionId={id}
+            editable={userCanEdit && (status === "pending" || status === "accepted")}
+          />
         </div>
       )}
 
@@ -80,20 +84,23 @@ export function Suggestion({ suggestion }: Props) {
       {/* Packages */}
       <div className="rounded border box column gap">
         <h2 className="text-l bold text-gray">Matching in nixpkgs</h2>
-        <CategorizedPackagesList active={packages} ignored={ignored_packages} />
+        <CategorizedPackagesList suggestionId={id} active={packages} ignored={ignored_packages} />
       </div>
 
       {/* Maintainers */}
       {categorized_maintainers.active.length > 0 && (
         <div className="rounded border box column gap">
           <h2 className="text-l bold text-gray">Maintainers</h2>
-          <CategorizedMaintainersList categorizedMaintainers={categorized_maintainers} />
+          <CategorizedMaintainersList
+            suggestionId={id}
+            categorizedMaintainers={categorized_maintainers}
+          />
         </div>
       )}
 
       {/* Comment */}
-      {(comment || canEdit) && (
-        <Comment suggestionId={id} comment={comment ?? null} canEdit={canEdit} />
+      {(comment || userCanEdit) && (
+        <Comment suggestionId={id} comment={comment ?? null} canEdit={userCanEdit} />
       )}
     </article>
   );

--- a/frontend/src/components/ui/Toaster.module.css
+++ b/frontend/src/components/ui/Toaster.module.css
@@ -1,0 +1,62 @@
+/* Functional plumbing required by Ark UI for the toast to position/animate
+ * correctly (driven by runtime custom properties). Not look-and-feel —
+ * see https://ark-ui.com/react/docs/components/toast#styling */
+.root {
+  position: relative;
+  width: 24em;
+  max-width: calc(100vw - 2em);
+  /* Not using the `.box` utility class here: it sets `overflow: auto`, which
+   * clashes with Ark UI's internal `data-ghost` helper elements (used for
+   * the stacking animation) — their transformed bounding boxes exceed the
+   * root's own box, so `overflow: auto` produces a spurious scrollbar. */
+  padding: 1em;
+  padding-right: 2.2em;
+  translate: var(--x) var(--y);
+  scale: var(--scale);
+  z-index: var(--z-index);
+  height: var(--height);
+  opacity: var(--opacity);
+  will-change: translate, opacity, scale;
+  transition:
+    translate 400ms,
+    scale 400ms,
+    opacity 400ms,
+    height 400ms,
+    box-shadow 200ms;
+  transition-timing-function: cubic-bezier(0.21, 1.02, 0.73, 1);
+}
+
+.root[data-state="closed"] {
+  transition:
+    translate 400ms,
+    scale 400ms,
+    opacity 200ms;
+  transition-timing-function: cubic-bezier(0.06, 0.71, 0.55, 1);
+}
+
+@media (max-width: 640px) {
+  .group {
+    width: 100%;
+  }
+
+  .root {
+    inset-inline: 0;
+    width: calc(100% - var(--gap) * 2);
+  }
+}
+
+.closeTrigger {
+  position: absolute;
+  top: 0.6em;
+  right: 0.6em;
+  background: none;
+  border: none;
+  padding: 0.2em;
+  color: inherit;
+  cursor: pointer;
+  opacity: 0.8;
+}
+
+.closeTrigger:hover {
+  opacity: 1;
+}

--- a/frontend/src/components/ui/Toaster.tsx
+++ b/frontend/src/components/ui/Toaster.tsx
@@ -1,0 +1,62 @@
+import {
+  Toaster as ArkToaster,
+  type CreateToasterReturn,
+  ToastCloseTrigger,
+  ToastDescription,
+  ToastRoot,
+  ToastTitle,
+} from "@ark-ui/react";
+import {
+  CircleCheckIcon,
+  CircleXIcon,
+  InfoIcon,
+  Loader2Icon,
+  TriangleAlertIcon,
+  XIcon,
+} from "lucide-preact";
+import styles from "./Toaster.module.css";
+
+type ToasterProps = {
+  toaster: CreateToasterReturn;
+};
+
+const typeToFg: Record<string, string> = {
+  error: "text-white",
+};
+
+const typeToBg: Record<string, string> = {
+  error: "bg-red",
+  warning: "bg-yellow-light",
+};
+
+const typeToIcon: Record<string, typeof InfoIcon> = {
+  error: CircleXIcon,
+  success: CircleCheckIcon,
+  warning: TriangleAlertIcon,
+  info: InfoIcon,
+  loading: Loader2Icon,
+};
+
+export function Toaster({ toaster }: ToasterProps) {
+  return (
+    <ArkToaster toaster={toaster} className={styles.group}>
+      {(toast) => {
+        const Icon = typeToIcon[toast.type ?? ""] ?? InfoIcon;
+        return (
+          <ToastRoot
+            className={`rounded shadow column gap-small ${typeToFg[toast.type ?? ""]} ${typeToBg[toast.type ?? ""] ?? "bg-gray"} ${styles.root}`}
+          >
+            <ToastTitle className="row gap-small centered bold">
+              <Icon size="1.2em" />
+              {toast.title}
+            </ToastTitle>
+            {toast.description && <ToastDescription>{toast.description}</ToastDescription>}
+            <ToastCloseTrigger className={`row centered ${styles.closeTrigger}`}>
+              <XIcon size="1em" />
+            </ToastCloseTrigger>
+          </ToastRoot>
+        );
+      }}
+    </ArkToaster>
+  );
+}

--- a/frontend/src/hooks/useReference.ts
+++ b/frontend/src/hooks/useReference.ts
@@ -1,0 +1,76 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { ApiError } from "@/api/client";
+import {
+  getGetSuggestionActivityLogQueryKey,
+  getGetSuggestionQueryKey,
+  useUpdateSuggestionReference,
+} from "@/api/generated/endpoints";
+import type { PatchedSuggestionReferenceUpdate, Suggestion } from "@/api/generated/models";
+import { getApiErrorMessage } from "@/utils/apiError";
+import { toaster } from "@/utils/toaster";
+
+type MutationVars = { id: number; data: PatchedSuggestionReferenceUpdate };
+type MutationContext = { previous?: Suggestion };
+
+export function useReferenceMutation(suggestionId: number) {
+  const queryClient = useQueryClient();
+  const queryKey = getGetSuggestionQueryKey(suggestionId);
+
+  return useUpdateSuggestionReference({
+    mutation: {
+      onMutate: async ({ data }: MutationVars): Promise<MutationContext> => {
+        await queryClient.cancelQueries({ queryKey });
+        const previous = queryClient.getQueryData<Suggestion>(queryKey);
+
+        queryClient.setQueryData<Suggestion>(queryKey, (prev) => {
+          if (!prev) return prev;
+          const { reference_url, ignored } = data;
+          const refs = prev.categorized_url_references;
+          const fromKey = ignored ? "active" : "ignored";
+          const toKey = ignored ? "ignored" : "active";
+          const moving = refs[fromKey].find((r) => r.url === reference_url);
+          if (!moving) return prev;
+
+          return {
+            ...prev,
+            categorized_url_references: {
+              ...refs,
+              [fromKey]: refs[fromKey].filter((r) => r.url !== reference_url),
+              [toKey]: [...refs[toKey], moving],
+            },
+          };
+        });
+
+        return { previous };
+      },
+      onError: (err: unknown, vars: MutationVars, context?: MutationContext) => {
+        const description = getApiErrorMessage(err);
+        if (err instanceof ApiError && err.status === 400) {
+          // Likely a stale-state conflict (e.g. another user already ignored/restored this reference).
+          // The cached `previous` snapshot is stale too, so refetch instead of rolling back to it.
+          const title = vars.data.ignored
+            ? "Reference already ignored"
+            : "Reference already restored";
+          const description =
+            "The suggestion might have been stale. It has been re-synchronized with the server.";
+          queryClient.invalidateQueries({ queryKey });
+          toaster.warning({ title, description });
+        } else if (context?.previous) {
+          const title = vars.data.ignored
+            ? "Failed to ignore reference"
+            : "Failed to restore reference";
+          queryClient.setQueryData(queryKey, context.previous);
+          toaster.error({ title, description });
+        }
+      },
+      onSuccess: () => {
+        // A new activity log entry is created server-side.
+        // The suggestion cache is correct via the optimistic update above.
+        // We only refresh the activity log.
+        queryClient.invalidateQueries({
+          queryKey: getGetSuggestionActivityLogQueryKey(suggestionId),
+        });
+      },
+    },
+  });
+}

--- a/frontend/src/hooks/useTick.ts
+++ b/frontend/src/hooks/useTick.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from "preact/hooks";
+
+type Listener = () => void;
+
+// Registry of shared tickers, keyed by interval duration. Every component
+// calling `useTick` with the same `intervalMs` subscribes to the same
+// `setInterval`, so rendering the same tick rate from many places (e.g. once
+// per row in a list) never creates more than one timer per unique interval.
+const tickers = new Map<number, { id: ReturnType<typeof setInterval>; listeners: Set<Listener> }>();
+
+function subscribe(intervalMs: number, listener: Listener): () => void {
+  let ticker = tickers.get(intervalMs);
+  if (!ticker) {
+    const listeners = new Set<Listener>();
+    const id = setInterval(() => {
+      for (const l of listeners) l();
+    }, intervalMs);
+    ticker = { id, listeners };
+    tickers.set(intervalMs, ticker);
+  }
+  ticker.listeners.add(listener);
+
+  return () => {
+    ticker.listeners.delete(listener);
+    if (ticker.listeners.size === 0) {
+      clearInterval(ticker.id);
+      tickers.delete(intervalMs);
+    }
+  };
+}
+
+/**
+ * Forces the calling component to re-render every `intervalMs` milliseconds.
+ *
+ * Components requesting the same `intervalMs` share a single underlying
+ * timer, so this stays cheap even when called from many components at once.
+ */
+export function useTick(intervalMs: number): void {
+  const [, setTick] = useState(0);
+
+  useEffect(() => subscribe(intervalMs, () => setTick((t) => t + 1)), [intervalMs]);
+}

--- a/frontend/src/routes/Home.tsx
+++ b/frontend/src/routes/Home.tsx
@@ -12,14 +12,14 @@ const doneFeatures = [
   "Viewing suggestion info: maintainers",
   "Viewing suggestion info: activity log",
   "Viewing suggestion info: comments",
+  "Suggestions: comment edit",
+  "Suggestions: reference ignore/restore",
 ];
 
 const pendingFeatures = [
   "Suggestions: package ignore/restore",
   "Suggestions: maintainer ignore/restore",
   "Suggestions: maintainer add/delete",
-  "Suggestions: reference ignore/restore",
-  "Suggestions: comment edit",
   "Suggestions: status change",
   "Notification center",
   "Notification pill (in navbar)",

--- a/frontend/src/utils/apiError.ts
+++ b/frontend/src/utils/apiError.ts
@@ -1,0 +1,22 @@
+import { ApiError } from "@/api/client";
+
+/**
+ * Extracts a human-readable message from an error thrown by `apiFetch`.
+ */
+export function getApiErrorMessage(error: unknown): string {
+  if (error instanceof ApiError) {
+    const body = error.body;
+    if (body && typeof body === "object") {
+      if ("detail" in body && typeof body.detail === "string") {
+        return body.detail;
+      }
+
+      const [field, messages] = Object.entries(body)[0] ?? [];
+      if (field && Array.isArray(messages) && typeof messages[0] === "string") {
+        return `${field}: ${messages[0]}`;
+      }
+    }
+  }
+
+  return "Check your connection and try again";
+}

--- a/frontend/src/utils/toaster.ts
+++ b/frontend/src/utils/toaster.ts
@@ -1,0 +1,10 @@
+import { createToaster } from "@ark-ui/react";
+
+// How long toasts stay visible
+const DURATION_MS = 10_000;
+
+// Shared app-wide toaster instance.
+export const toaster = createToaster({
+  placement: "bottom-end",
+  duration: DURATION_MS,
+});

--- a/src/api/suggestions/serializers.py
+++ b/src/api/suggestions/serializers.py
@@ -13,6 +13,18 @@ from shared.logs.batches import (
 from shared.models.linkage import CVEDerivationClusterProposal
 
 
+class SuggestionReferenceUpdateSerializer(serializers.Serializer):
+    """Request body for ignore/restore reference PATCH operations."""
+
+    reference_url = serializers.URLField(
+        max_length=2048,
+        help_text="URL of the reference to ignore or restore.",
+    )
+    ignored = serializers.BooleanField(
+        help_text="Set to true to ignore the reference, false to restore it.",
+    )
+
+
 class SuggestionCommentSerializer(serializers.Serializer):
     """Serializer for reading or updating a suggestion comment."""
 

--- a/src/api/suggestions/views.py
+++ b/src/api/suggestions/views.py
@@ -1,7 +1,9 @@
+from django.core.exceptions import ValidationError
 from drf_spectacular.utils import extend_schema, extend_schema_serializer
 from rest_framework import serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import MethodNotAllowed
+from rest_framework.exceptions import ValidationError as DRFValidationError
 from rest_framework.mixins import RetrieveModelMixin
 from rest_framework.permissions import AllowAny, BasePermission, IsAuthenticated
 from rest_framework.request import Request
@@ -11,7 +13,9 @@ from rest_framework.views import APIView
 from api.serializers import ErrorDetailSerializer
 from api.suggestions.serializers import (
     ActivityLogEntrySerializer,
+    SuggestionCategorizedUrlReferencesSerializer,
     SuggestionCommentSerializer,
+    SuggestionReferenceUpdateSerializer,
     SuggestionSerializer,
     folded_event_to_dict,
 )
@@ -170,5 +174,58 @@ class SuggestionViewSet(RetrieveModelMixin, viewsets.GenericViewSet):
             instance = self.get_object()
             instance.set_comment(serializer.validated_data["comment"])
             return Response(self.get_serializer(instance).data)
+        else:
+            raise MethodNotAllowed(request.method)
+
+    @extend_schema(
+        methods=["get"],
+        operation_id="getSuggestionReferences",
+        description="Get the categorized URL references of a suggestion (original, active, ignored).",
+        responses={
+            200: SuggestionCategorizedUrlReferencesSerializer,
+            404: ErrorDetailSerializer,
+        },
+    )
+    @extend_schema(
+        methods=["patch"],
+        operation_id="updateSuggestionReference",
+        description="Ignore or restore a URL reference. Send `ignored: true` to ignore, `ignored: false` to restore.",
+        request=SuggestionReferenceUpdateSerializer,
+        responses={
+            204: None,
+            400: ErrorDetailSerializer,
+            403: ErrorDetailSerializer,
+            404: ErrorDetailSerializer,
+        },
+    )
+    @action(
+        detail=True,
+        methods=["get", "patch"],
+        url_path="references",
+        serializer_class=SuggestionReferenceUpdateSerializer,
+    )
+    def references(self, request: Request, pk: int) -> Response:
+        if request.method == "GET":
+            instance = self.get_object()
+            instance.ensure_fresh_cache()
+            data = instance.cached.payload["categorized_url_references"]
+            return Response(SuggestionCategorizedUrlReferencesSerializer(data).data)
+        elif request.method == "PATCH":
+            serializer = self.get_serializer(data=request.data)
+            serializer.is_valid(raise_exception=True)
+            instance = self.get_object()
+            instance.ensure_fresh_cache()
+            try:
+                if serializer.validated_data["ignored"]:
+                    instance.ignore_reference(
+                        serializer.validated_data["reference_url"]
+                    )
+                else:
+                    instance.restore_reference(
+                        serializer.validated_data["reference_url"]
+                    )
+            except ValidationError as e:
+                raise DRFValidationError(e.message_dict)
+            return Response(status=204)
         else:
             raise MethodNotAllowed(request.method)

--- a/src/api/tests/test_suggestion_references.py
+++ b/src/api/tests/test_suggestion_references.py
@@ -1,0 +1,199 @@
+from collections.abc import Callable
+
+import pytest
+from django.contrib.auth.models import User
+from rest_framework.reverse import reverse
+from rest_framework.test import APIClient
+
+from shared.models.cve import Container
+from shared.models.linkage import CVEDerivationClusterProposal
+
+REFERENCE_URL = "https://example.com/advisory"
+REFERENCE_NAME = "Advisory"
+
+
+def url(id: int) -> str:
+    return reverse("cvederivationclusterproposal-references", kwargs={"pk": id})
+
+
+@pytest.fixture
+def suggestion_with_reference(
+    make_container: Callable[..., Container],
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> CVEDerivationClusterProposal:
+    container = make_container(references=[(REFERENCE_NAME, REFERENCE_URL, [])])
+    return make_cached_suggestion(container=container)
+
+
+def test_get_references_anonymous(
+    suggestion_with_reference: CVEDerivationClusterProposal,
+) -> None:
+    client = APIClient()
+    response = client.get(url(suggestion_with_reference.pk))
+    assert response.status_code == 200
+    data = response.data
+    assert "original" in data
+    assert "active" in data
+    assert "ignored" in data
+    assert any(r["url"] == REFERENCE_URL for r in data["original"])
+    assert any(r["url"] == REFERENCE_URL for r in data["active"])
+    assert data["ignored"] == []
+
+
+def test_get_references_not_found(
+    suggestion_with_reference: CVEDerivationClusterProposal,
+) -> None:
+    client = APIClient()
+    response = client.get(url(suggestion_with_reference.pk + 1))
+    assert response.status_code == 404
+
+
+def test_patch_ignore_unauthenticated(
+    suggestion_with_reference: CVEDerivationClusterProposal,
+) -> None:
+    client = APIClient()
+    response = client.patch(
+        url(suggestion_with_reference.pk),
+        {"reference_url": REFERENCE_URL, "ignored": True},
+        format="json",
+    )
+    assert response.status_code == 401
+
+
+def test_patch_ignore_non_committer(
+    suggestion_with_reference: CVEDerivationClusterProposal,
+    user: User,
+) -> None:
+    client = APIClient()
+    client.force_login(user)
+    response = client.patch(
+        url(suggestion_with_reference.pk),
+        {"reference_url": REFERENCE_URL, "ignored": True},
+        format="json",
+    )
+    assert response.status_code == 403
+
+
+def test_patch_ignore_reference_not_found(
+    suggestion_with_reference: CVEDerivationClusterProposal,
+    committer: User,
+) -> None:
+    client = APIClient()
+    client.force_login(committer)
+    response = client.patch(
+        url(suggestion_with_reference.pk),
+        {"reference_url": f"{REFERENCE_URL}/some_suffix", "ignored": True},
+        format="json",
+    )
+    assert response.status_code == 400
+
+
+def test_patch_ignore_reference_success(
+    suggestion_with_reference: CVEDerivationClusterProposal,
+    committer: User,
+) -> None:
+    client = APIClient()
+    client.force_login(committer)
+    response = client.patch(
+        url(suggestion_with_reference.pk),
+        {"reference_url": REFERENCE_URL, "ignored": True},
+        format="json",
+    )
+    assert response.status_code == 204
+
+    # Verify the reference moved to ignored
+    get_response = client.get(url(suggestion_with_reference.pk))
+    assert get_response.status_code == 200
+    data = get_response.data
+    assert not any(r["url"] == REFERENCE_URL for r in data["active"])
+    assert any(r["url"] == REFERENCE_URL for r in data["ignored"])
+
+
+def test_patch_ignore_reference_already_ignored(
+    suggestion_with_reference: CVEDerivationClusterProposal,
+    committer: User,
+) -> None:
+    client = APIClient()
+    client.force_login(committer)
+    # First ignore
+    client.patch(
+        url(suggestion_with_reference.pk),
+        {"reference_url": REFERENCE_URL, "ignored": True},
+        format="json",
+    )
+    # Second ignore should fail
+    response = client.patch(
+        url(suggestion_with_reference.pk),
+        {"reference_url": REFERENCE_URL, "ignored": True},
+        format="json",
+    )
+    assert response.status_code == 400
+
+
+def test_patch_restore_unauthenticated(
+    suggestion_with_reference: CVEDerivationClusterProposal,
+) -> None:
+    client = APIClient()
+    response = client.patch(
+        url(suggestion_with_reference.pk),
+        {"reference_url": REFERENCE_URL, "ignored": False},
+        format="json",
+    )
+    assert response.status_code == 401
+
+
+def test_patch_restore_non_committer(
+    suggestion_with_reference: CVEDerivationClusterProposal,
+    user: User,
+) -> None:
+    client = APIClient()
+    client.force_login(user)
+    response = client.patch(
+        url(suggestion_with_reference.pk),
+        {"reference_url": REFERENCE_URL, "ignored": False},
+        format="json",
+    )
+    assert response.status_code == 403
+
+
+def test_patch_restore_reference_not_in_ignored(
+    suggestion_with_reference: CVEDerivationClusterProposal,
+    committer: User,
+) -> None:
+    client = APIClient()
+    client.force_login(committer)
+    # Not yet ignored, so restoring should fail
+    response = client.patch(
+        url(suggestion_with_reference.pk),
+        {"reference_url": REFERENCE_URL, "ignored": False},
+        format="json",
+    )
+    assert response.status_code == 400
+
+
+def test_patch_restore_reference_success(
+    suggestion_with_reference: CVEDerivationClusterProposal,
+    committer: User,
+) -> None:
+    client = APIClient()
+    client.force_login(committer)
+    # First ignore
+    client.patch(
+        url(suggestion_with_reference.pk),
+        {"reference_url": REFERENCE_URL, "ignored": True},
+        format="json",
+    )
+    # Then restore
+    response = client.patch(
+        url(suggestion_with_reference.pk),
+        {"reference_url": REFERENCE_URL, "ignored": False},
+        format="json",
+    )
+    assert response.status_code == 204
+
+    # Verify the reference is back in active
+    get_response = client.get(url(suggestion_with_reference.pk))
+    assert get_response.status_code == 200
+    data = get_response.data
+    assert any(r["url"] == REFERENCE_URL for r in data["active"])
+    assert not any(r["url"] == REFERENCE_URL for r in data["ignored"])

--- a/src/shared/models/linkage.py
+++ b/src/shared/models/linkage.py
@@ -4,7 +4,7 @@ from typing import Any
 import pghistory
 import pgtrigger
 from django.core.exceptions import ValidationError
-from django.db import models
+from django.db import models, transaction
 from django.db.models import Q
 from django.db.models.signals import post_delete, post_save
 from django.db.utils import InternalError
@@ -181,6 +181,58 @@ class CVEDerivationClusterProposal(TimeStampMixin):
             package_attribute=package,
             overlay_type=PackageOverlay.Type.IGNORED,
         ).delete()
+
+    def ignore_reference(self, reference_url: str) -> None:
+        """Ignore a URL reference, updating the overlay and the cache."""
+        cat_refs = self.cached.payload["categorized_url_references"]
+        ref = next((r for r in cat_refs["original"] if r["url"] == reference_url), None)
+        if ref is None:
+            raise ValidationError(
+                {"reference_url": "Reference not found in the suggestion"}
+            )
+        if self.reference_url_overlays.filter(
+            reference_url=reference_url, type=ReferenceUrlOverlay.Type.IGNORED
+        ).exists():
+            raise ValidationError({"reference_url": "Reference is already ignored"})
+
+        with transaction.atomic():
+            self.reference_url_overlays.get_or_create(
+                reference_url=reference_url,
+                defaults={
+                    "deduplicated_name": ref["name"],
+                    "type": ReferenceUrlOverlay.Type.IGNORED,
+                },
+            )
+            cat_refs["active"] = [
+                r for r in cat_refs["active"] if r["url"] != reference_url
+            ]
+            cat_refs["ignored"].append(ref)
+            self.cached.save()
+
+    def restore_reference(self, reference_url: str) -> None:
+        """Restore a previously ignored URL reference."""
+        cat_refs = self.cached.payload["categorized_url_references"]
+        ref = next((r for r in cat_refs["ignored"] if r["url"] == reference_url), None)
+        if ref is None:
+            raise ValidationError(
+                {"reference_url": "Reference not found in ignored references"}
+            )
+
+        overlay = self.reference_url_overlays.filter(
+            reference_url=reference_url, type=ReferenceUrlOverlay.Type.IGNORED
+        ).first()
+        if not overlay:
+            raise ValidationError(
+                {"reference_url": "No ignore overlay found for this reference"}
+            )
+
+        with transaction.atomic():
+            overlay.delete()
+            cat_refs["ignored"] = [
+                r for r in cat_refs["ignored"] if r["url"] != reference_url
+            ]
+            cat_refs["active"].append(ref)
+            self.cached.save()
 
     def set_comment(self, comment: str | None) -> None:
         """Update the free-text comment independently of status changes."""

--- a/src/webview/tests/ui_v2/test_suggestion_references.py
+++ b/src/webview/tests/ui_v2/test_suggestion_references.py
@@ -1,0 +1,150 @@
+from collections.abc import Callable
+
+import pytest
+from playwright.sync_api import Page, expect
+from pytest_django.live_server_helper import LiveServer
+
+from shared.models.cve import Container
+from shared.models.linkage import CVEDerivationClusterProposal
+
+from .routes import SUGGESTION_DETAIL
+
+REFERENCE_URL = "https://example.com/advisory"
+REFERENCE_NAME = "Advisory"
+
+
+@pytest.fixture
+def suggestion_with_reference(
+    make_container: Callable[..., Container],
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> Callable[..., CVEDerivationClusterProposal]:
+    def wrapped(**kwargs: object) -> CVEDerivationClusterProposal:
+        container = make_container(references=[(REFERENCE_NAME, REFERENCE_URL, [])])
+        return make_cached_suggestion(container=container, **kwargs)
+
+    return wrapped
+
+
+@pytest.mark.django_db
+def test_reference_no_ignore_button_for_anonymous(
+    live_server: LiveServer,
+    page: Page,
+    suggestion_with_reference: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Anonymous users can see references but not the Ignore action."""
+    suggestion = suggestion_with_reference()
+    page.goto(live_server.url + SUGGESTION_DETAIL + f"/{suggestion.pk}")
+    references = page.get_by_test_id(f"suggestion-{suggestion.pk}-references")
+    expect(references.get_by_role("link", name=REFERENCE_NAME)).to_be_visible()
+    expect(references.get_by_role("button", name="Ignore")).to_be_hidden()
+
+
+@pytest.mark.django_db
+def test_reference_ignore_button_visible_for_committer(
+    live_server: LiveServer,
+    as_committer: Page,
+    suggestion_with_reference: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Committers see the Ignore action for an active reference on an editable suggestion."""
+    suggestion = suggestion_with_reference(
+        status=CVEDerivationClusterProposal.Status.PENDING
+    )
+    as_committer.goto(live_server.url + SUGGESTION_DETAIL + f"/{suggestion.pk}")
+    references = as_committer.get_by_test_id(f"suggestion-{suggestion.pk}-references")
+    expect(references.get_by_role("button", name="Ignore")).to_be_visible()
+
+
+@pytest.mark.django_db
+def test_reference_ignore_button_hidden_when_suggestion_rejected(
+    live_server: LiveServer,
+    as_committer: Page,
+    suggestion_with_reference: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Once a suggestion is rejected (frozen), references can no longer be edited."""
+    suggestion = suggestion_with_reference(
+        status=CVEDerivationClusterProposal.Status.REJECTED
+    )
+    as_committer.goto(live_server.url + SUGGESTION_DETAIL + f"/{suggestion.pk}")
+    references = as_committer.get_by_test_id(f"suggestion-{suggestion.pk}-references")
+    expect(references.get_by_role("link", name=REFERENCE_NAME)).to_be_visible()
+    expect(references.get_by_role("button", name="Ignore")).to_be_hidden()
+
+
+@pytest.mark.django_db
+def test_reference_ignore_moves_to_ignored_section_and_logs_activity(
+    live_server: LiveServer,
+    as_committer: Page,
+    suggestion_with_reference: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Clicking Ignore moves the reference into the Ignored references section
+    and records an activity log entry."""
+    suggestion = suggestion_with_reference(
+        status=CVEDerivationClusterProposal.Status.PENDING
+    )
+    as_committer.goto(live_server.url + SUGGESTION_DETAIL + f"/{suggestion.pk}")
+    references = as_committer.get_by_test_id(f"suggestion-{suggestion.pk}-references")
+
+    references.get_by_role("button", name="Ignore").click()
+
+    expect(references.get_by_text("Ignored references", exact=False)).to_be_visible()
+    references.get_by_text("Ignored references", exact=False).click()
+    expect(references.get_by_role("button", name="Restore")).to_be_visible()
+
+    activity_log = as_committer.get_by_test_id(
+        f"suggestion-{suggestion.pk}-activity-log"
+    )
+    activity_log.locator("summary").click()
+    expect(activity_log.get_by_text("ignored reference", exact=False)).to_be_visible()
+
+
+@pytest.mark.django_db
+def test_reference_restore_moves_back_to_active_section(
+    live_server: LiveServer,
+    as_committer: Page,
+    suggestion_with_reference: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Clicking Restore on an ignored reference moves it back to the active list."""
+    suggestion = suggestion_with_reference(
+        status=CVEDerivationClusterProposal.Status.PENDING
+    )
+    as_committer.goto(live_server.url + SUGGESTION_DETAIL + f"/{suggestion.pk}")
+    references = as_committer.get_by_test_id(f"suggestion-{suggestion.pk}-references")
+
+    references.get_by_role("button", name="Ignore").click()
+    references.get_by_text("Ignored references", exact=False).click()
+    expect(references.get_by_role("button", name="Restore")).to_be_visible()
+
+    references.get_by_role("button", name="Restore").click()
+
+    expect(references.get_by_role("button", name="Ignore")).to_be_visible()
+    expect(references.get_by_text("Ignored references", exact=False)).to_be_hidden()
+
+
+@pytest.mark.django_db
+def test_reference_ignore_shows_error_toast_on_backend_mismatch(
+    live_server: LiveServer,
+    as_committer: Page,
+    suggestion_with_reference: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """If the reference was already ignored server-side (e.g. by another
+    committer, or a stale tab) by the time the user clicks Ignore, the
+    optimistic update is rolled back and an error message is shown."""
+    suggestion = suggestion_with_reference(
+        status=CVEDerivationClusterProposal.Status.PENDING
+    )
+    as_committer.goto(live_server.url + SUGGESTION_DETAIL + f"/{suggestion.pk}")
+    references = as_committer.get_by_test_id(f"suggestion-{suggestion.pk}-references")
+    expect(references.get_by_role("button", name="Ignore")).to_be_visible()
+
+    # Simulate a UI/backend mismatch
+    suggestion.ignore_reference(REFERENCE_URL)
+
+    references.get_by_role("button", name="Ignore").click()
+
+    expect(as_committer.get_by_text("Reference already ignored")).to_be_visible()
+    expect(
+        as_committer.get_by_text("The suggestion might have been stale.", exact=False)
+    ).to_be_visible()
+
+    # The suggestion is supposed to have been refreshed so the reference should be ignored now
+    expect(references.get_by_text("Ignored references", exact=False)).to_be_visible()


### PR DESCRIPTION
- API endpoints to ignore/restore suggestion references
    - With model-level methods to ignore/restore
    - With tests
- Implementation in new UI
    - Fits legacy UI design
    - Snappy optimistic updates when clicking on the buttons
    - Future proofing
        - Auto update activity log
        - Live update of relative times in activity log after mutation
        - Popup errors mechanism for unexpected API or network errors (or other on-the-spot messages)
        - Automatic refresh of the suggestion when a stale-state is suspected from a 4xx API error (which is not possible when the suggestion does show the current state): this can happen if another user edits the suggestion at the same time as you, or you have several tabs open, or both legacy and new UI
    - Tests