### PR TITLE
feat: matching training data schema and roundtrip

### DIFF
--- a/src/shared/evaluation.py
+++ b/src/shared/evaluation.py
@@ -3,7 +3,7 @@ import logging
 import time
 from collections.abc import Callable, Generator
 from dataclasses import dataclass, field
-from typing import Any, TypeVar
+from typing import Any, NamedTuple, TypeVar
 
 from dataclass_wizard import JSONWizard, LoadMixin
 from django.db.models import Model
@@ -60,6 +60,13 @@ class MetadataAttribute(JSONWizard, LoadMixin):
     known_vulnerabilities: list[str] = field(default_factory=list)
 
 
+class DerivationKey(NamedTuple):
+    drv_path: str
+    attr: str
+    name: str
+    meta_name: str | None
+
+
 @dataclass
 class EvaluatedAttribute(JSONWizard):
     """
@@ -74,27 +81,44 @@ class EvaluatedAttribute(JSONWizard):
     outputs: dict[str, str]
     system: str
 
-    def as_key(self) -> tuple[str, str, str, str | None]:
-        """
-        Unique dictionary key for a derivation
-
-        These are the actual degrees of freedom for a derivation, judging from the data.
-        """
-        # FIXME(@fricklerhandwerk): We should only need the derivation path!
-        # Extract the extra fields to save more space.
-        # A `NixPackage` could indeed consist of just `pname` (parsed from `name`, validate against `attribute` and `drv_metadata.name`).
-        # Then we'd describe all occurrences of a `NixPackage` with
-        # - NixDerivation
-        # - attribute_name
-        # - metadata__name
-        # - parent_evaluation (also extracted since derivation paths of close-to-root packages can be the same across evaluations)
-        # - version (also parsed from `name`, for easier querying)
-        return (
-            self.drv_path,
-            self.attr,
-            self.name,
-            self.meta.name or None if self.meta else None,
+    def as_key(self) -> DerivationKey:
+        """Unique dictionary key for a derivation (see :func:`derivation_as_key`)."""
+        return derivation_as_key(
+            drv_path=self.drv_path,
+            attr=self.attr,
+            name=self.name,
+            meta_name=self.meta.name or None if self.meta else None,
         )
+
+
+def derivation_as_key(
+    *,
+    drv_path: str,
+    attr: str,
+    name: str,
+    meta_name: str | None,
+) -> DerivationKey:
+    """
+    Unique dictionary key for a derivation.
+
+    These are the actual degrees of freedom for a derivation, judging from the data.
+    Shared by evaluation ingestion and matching training-data import.
+    """
+    # FIXME(@fricklerhandwerk): We should only need the derivation path!
+    # Extract the extra fields to save more space.
+    # A `NixPackage` could indeed consist of just `pname` (parsed from `name`, validate against `attribute` and `drv_metadata.name`).
+    # Then we'd describe all occurrences of a `NixPackage` with
+    # - NixDerivation
+    # - attribute_name
+    # - metadata__name
+    # - parent_evaluation (also extracted since derivation paths of close-to-root packages can be the same across evaluations)
+    # - version (also parsed from `name`, for easier querying)
+    return DerivationKey(
+        drv_path=drv_path,
+        attr=attr,
+        name=name,
+        meta_name=meta_name,
+    )
 
 
 @dataclass
@@ -159,7 +183,7 @@ def parse_evaluation_result(line: str) -> PartialEvaluatedAttribute:
 
 def by_drv_key[T](
     gen: Generator[tuple[EvaluatedAttribute, list[T]]],
-) -> dict[tuple[str, str, str, str | None], list[T]]:
+) -> dict[DerivationKey, list[T]]:
     return dict((origin.as_key(), elements) for origin, elements in gen)
 
 
@@ -288,7 +312,7 @@ class SyncBatchAttributeIngester:
 
     def ingest(self) -> list[NixDerivation]:
         start = time.time()
-        bulk_derivations: dict[tuple[str, str, str, str | None], NixDerivation] = {}
+        bulk_derivations: dict[DerivationKey, NixDerivation] = {}
         bulk_maintainers: dict[int, NixMaintainer] = {}
         bulk_licenses: dict[str, NixLicense] = {}
         metadata = []

--- a/src/shared/matching_training_data/__init__.py
+++ b/src/shared/matching_training_data/__init__.py
@@ -1,0 +1,13 @@
+"""Matching training-data roundtrip."""
+
+from shared.matching_training_data import serializers
+from shared.matching_training_data.serializers import (
+    SCHEMA_VERSION,
+    ensure_benchmark_evaluation,
+)
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "ensure_benchmark_evaluation",
+    "serializers",
+]

--- a/src/shared/matching_training_data/serializers.py
+++ b/src/shared/matching_training_data/serializers.py
@@ -1,0 +1,418 @@
+"""DRF ModelSerializers for matching training-data roundtrip.
+
+The exported derivation and CVE data is exactly what we assume is required for
+matching them reproducibly.
+Adapt that appropriately when the matching algorithm changes.
+
+Serializers are named after the models they read/write. Export with
+``CVEDerivationClusterProposal(instance).data``; import with
+``CVEDerivationClusterProposal(data=...).is_valid(); .save()``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, cast
+
+from django.db import transaction
+from rest_framework import serializers
+
+from shared import models
+from shared.evaluation import DerivationKey, derivation_as_key
+
+SCHEMA_VERSION = 1
+
+# Synthetic channel used when materializing a local benchmark corpus
+BENCHMARK_CHANNEL_BRANCH = "benchmark"
+BENCHMARK_RELEASE_BRANCH = "benchmark-master"
+
+# Fixed dummy git SHA so get_or_create stays obviously idempotent.
+_BENCHMARK_DUMMY_SHA1 = "0" * 40
+
+# Stable org for imported training CVEs
+_TRAINING_ORG_UUID = uuid.UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+
+
+def ensure_benchmark_evaluation() -> models.NixEvaluation:
+    """Create or reuse the synthetic benchmark channel + completed evaluation."""
+    release_branch, _ = models.NixpkgsBranch.objects.get_or_create(
+        name=BENCHMARK_RELEASE_BRANCH,
+        defaults={"head_sha1_commit": _BENCHMARK_DUMMY_SHA1},
+    )
+    channel, _ = models.NixChannel.objects.get_or_create(
+        channel_branch=BENCHMARK_CHANNEL_BRANCH,
+        defaults={
+            "release_branch": release_branch,
+            "state": models.NixChannel.ChannelState.UNSTABLE,
+            "head_sha1_commit": _BENCHMARK_DUMMY_SHA1,
+            "variant": None,
+        },
+    )
+    evaluation = (
+        models.NixEvaluation.objects.filter(
+            channel=channel,
+            state=models.NixEvaluation.EvaluationState.COMPLETED,
+        )
+        .order_by("-updated_at")
+        .first()
+    )
+    if evaluation is None:
+        evaluation = models.NixEvaluation.objects.create(
+            channel=channel,
+            commit_sha1=_BENCHMARK_DUMMY_SHA1,
+            state=models.NixEvaluation.EvaluationState.COMPLETED,
+        )
+    return evaluation
+
+
+def pick_first_container(
+    proposal: models.CVEDerivationClusterProposal,
+) -> models.Container | None:
+    """Prefer a container with ``package_name`` (needed for matching); else any first container."""
+    return (
+        proposal.cve.container.filter(affected__package_name__isnull=False).first()
+        or proposal.cve.container.first()
+    )
+
+
+def _training_drv_path(*, attribute: str, name: str, system: str) -> str:
+    """Stable synthetic drv path so :func:`derivation_as_key` stays deterministic."""
+    return f"/nix/store/training-{attribute}-{name}-{system}.drv"
+
+
+class AffectedProduct(serializers.ModelSerializer):
+    cpes = serializers.ListField(child=serializers.CharField(), required=False)
+
+    class Meta:
+        model = models.AffectedProduct
+        fields = (
+            "vendor",
+            "product",
+            "package_name",
+            "cpes",
+        )
+
+    def to_representation(self, instance: models.AffectedProduct) -> dict[str, Any]:
+        return {
+            "vendor": instance.vendor,
+            "product": instance.product,
+            "package_name": instance.package_name,
+            "cpes": sorted(cpe.name for cpe in instance.cpes.all()),
+        }
+
+
+class Container(serializers.Serializer):
+    """
+    Subset of Container fields relevant for training data
+    """
+
+    tags = serializers.ListField(child=serializers.CharField(), required=False)
+    affected = AffectedProduct(many=True, required=False)
+
+    def to_representation(self, instance: models.Container) -> dict[str, Any]:
+        affected = [
+            AffectedProduct().to_representation(product)
+            for product in instance.affected.all()
+        ]
+        return {
+            "tags": sorted(tag.value for tag in instance.tags.all()),
+            "affected": sorted(
+                affected,
+                key=lambda a: (
+                    a.get("package_name") or "",
+                    a.get("product") or "",
+                    a.get("vendor") or "",
+                    tuple(a.get("cpes") or []),
+                ),
+            ),
+        }
+
+
+class NixDerivation(serializers.ModelSerializer):
+    known_vulnerabilities = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+    )
+
+    class Meta:
+        model = models.NixDerivation
+        fields = ("attribute", "name", "system", "known_vulnerabilities")
+
+    def to_representation(self, instance: models.NixDerivation) -> dict[str, Any]:
+        known: list[str] = []
+        if instance.metadata_id is not None and instance.metadata is not None:
+            known = list(instance.metadata.known_vulnerabilities or [])
+        return {
+            "attribute": instance.attribute,
+            "name": instance.name,
+            "system": instance.system,
+            "known_vulnerabilities": known,
+        }
+
+
+class DerivationClusterProposalLink(serializers.ModelSerializer):
+    derivation = NixDerivation()
+
+    class Meta:
+        model = models.DerivationClusterProposalLink
+        fields = ("derivation", "provenance_flags")
+
+    def to_representation(
+        self, instance: models.DerivationClusterProposalLink
+    ) -> dict[str, Any]:
+        return cast(dict[str, Any], super().to_representation(instance))
+
+
+class PackageOverlay(serializers.ModelSerializer):
+    type = serializers.ChoiceField(choices=models.PackageOverlay.Type.choices)
+
+    class Meta:
+        model = models.PackageOverlay
+        fields = ("package_attribute", "type")
+
+    def to_representation(self, instance: models.PackageOverlay) -> dict[str, Any]:
+        return cast(dict[str, Any], super().to_representation(instance))
+
+
+class CVEDerivationClusterProposal(serializers.ModelSerializer):
+    """Versioned matching training-data record (export/import wire format)."""
+
+    # Not model fields, must be declared (wire-only version gate + cve.cve_id).
+    schema_version = serializers.IntegerField()
+    cve_id = serializers.CharField()
+    container = Container()
+    derivationclusterproposallink_set = DerivationClusterProposalLink(
+        many=True,
+        required=False,
+    )
+    package_overlays = PackageOverlay(many=True, required=False)
+    kept_derivations = serializers.SerializerMethodField()
+    ignored_packages = serializers.SerializerMethodField()
+    comment = serializers.CharField(allow_null=True, allow_blank=True, required=False)
+
+    class Meta:
+        model = models.CVEDerivationClusterProposal
+        fields = (
+            "schema_version",
+            "cve_id",
+            "container",
+            "status",
+            "rejection_reason",
+            "comment",
+            "rejection_match_count",
+            "rejection_max_matches_limit",
+            "algorithm_version",
+            "derivationclusterproposallink_set",
+            "package_overlays",
+            "kept_derivations",
+            "ignored_packages",
+        )
+        read_only_fields = ("kept_derivations", "ignored_packages")
+
+    def validate_schema_version(self, value: int) -> int:
+        if value != SCHEMA_VERSION:
+            raise serializers.ValidationError(
+                f"Unsupported matching training-data schema_version={value}; "
+                f"expected {SCHEMA_VERSION}"
+            )
+        return value
+
+    def get_ignored_packages(
+        self, obj: models.CVEDerivationClusterProposal
+    ) -> list[str]:
+        return sorted(
+            overlay.package_attribute
+            for overlay in obj.package_overlays.all()
+            if overlay.type == models.PackageOverlay.Type.IGNORED
+        )
+
+    def get_kept_derivations(
+        self, obj: models.CVEDerivationClusterProposal
+    ) -> list[dict[str, str]]:
+        if obj.status == models.CVEDerivationClusterProposal.Status.REJECTED:
+            return []
+        ignored = set(self.get_ignored_packages(obj))
+        kept = [
+            {
+                "attribute": link.derivation.attribute,
+                "name": link.derivation.name,
+                "system": link.derivation.system,
+            }
+            for link in obj.derivationclusterproposallink_set.all()
+            if link.derivation.attribute not in ignored
+        ]
+        return sorted(kept, key=lambda d: (d["attribute"], d["name"], d["system"]))
+
+    def to_representation(
+        self, instance: models.CVEDerivationClusterProposal
+    ) -> dict[str, Any]:
+        container = pick_first_container(instance)
+        if container is None:
+            raise ValueError(
+                f"Proposal {instance.pk} for {instance.cve.cve_id} has no CVE container"
+            )
+
+        links = [
+            DerivationClusterProposalLink().to_representation(link)
+            for link in instance.derivationclusterproposallink_set.select_related(
+                "derivation__metadata"
+            ).order_by(
+                "derivation__attribute",
+                "derivation__name",
+                "derivation__system",
+            )
+        ]
+        overlays = [
+            PackageOverlay().to_representation(overlay)
+            for overlay in instance.package_overlays.order_by(
+                "package_attribute",
+                "type",
+            )
+        ]
+
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "cve_id": instance.cve.cve_id,
+            "container": Container().to_representation(container),
+            "status": instance.status,
+            "rejection_reason": instance.rejection_reason,
+            "comment": instance.comment,
+            "rejection_match_count": instance.rejection_match_count,
+            "rejection_max_matches_limit": instance.rejection_max_matches_limit,
+            "algorithm_version": instance.algorithm_version,
+            "derivationclusterproposallink_set": links,
+            "package_overlays": overlays,
+            "kept_derivations": self.get_kept_derivations(instance),
+            "ignored_packages": self.get_ignored_packages(instance),
+        }
+
+    @transaction.atomic
+    def create(
+        self, validated_data: dict[str, Any]
+    ) -> models.CVEDerivationClusterProposal:
+        """
+        Materialize a training record on the synthetic benchmark channel.
+
+        Idempotent per ``cve_id``: any existing CVE with that id is replaced.
+        """
+        evaluation = ensure_benchmark_evaluation()
+        validated_data.pop("schema_version")
+        cve_id = validated_data.pop("cve_id")
+        container_data = validated_data.pop("container")
+        links_data = validated_data.pop("derivationclusterproposallink_set", [])
+        overlays_data = validated_data.pop("package_overlays", [])
+
+        models.CveRecord.objects.filter(cve_id=cve_id).delete()
+        org, _ = models.Organization.objects.get_or_create(
+            uuid=_TRAINING_ORG_UUID,
+            defaults={"short_name": "training-data"},
+        )
+
+        cve = models.CveRecord.objects.create(cve_id=cve_id, assigner=org)
+        container = models.Container.objects.create(
+            cve=cve,
+            provider=org,
+            title=f"Training data for {cve_id}",
+        )
+
+        tag_objs = []
+        for value in container_data.get("tags") or []:
+            tag, _ = models.Tag.objects.get_or_create(value=value)
+            tag_objs.append(tag)
+        if tag_objs:
+            container.tags.set(tag_objs)
+
+        for affected_data in container_data.get("affected") or []:
+            affected = models.AffectedProduct.objects.create(
+                vendor=affected_data.get("vendor"),
+                product=affected_data.get("product"),
+                package_name=affected_data.get("package_name"),
+            )
+            for cpe_name in affected_data.get("cpes") or []:
+                cpe, _ = models.Cpe.objects.get_or_create(name=cpe_name)
+                affected.cpes.add(cpe)
+            container.affected.add(affected)
+
+        by_fingerprint: dict[DerivationKey, models.NixDerivation] = {}
+        for link_data in links_data:
+            drv_data = link_data["derivation"]
+            attribute = drv_data["attribute"]
+            name = drv_data["name"]
+            system = drv_data["system"]
+            drv_path = _training_drv_path(attribute=attribute, name=name, system=system)
+            # Same uniqueness degrees of freedom as evaluation ingestion
+            # (shared.evaluation.derivation_as_key). Training JSON has no real
+            # drv_path, so we use a deterministic synthetic path that embeds
+            # attribute/name/system.
+            key = derivation_as_key(
+                drv_path=drv_path,
+                attr=attribute,
+                name=name,
+                meta_name=name,
+            )
+            if key not in by_fingerprint:
+                meta = models.NixDerivationMeta.objects.create(
+                    description="Imported training derivation",
+                    homepage=None,
+                    insecure=False,
+                    available=True,
+                    broken=False,
+                    unfree=False,
+                    unsupported=False,
+                    known_vulnerabilities=list(
+                        drv_data.get("known_vulnerabilities") or []
+                    ),
+                )
+                by_fingerprint[key] = models.NixDerivation.objects.create(
+                    attribute=attribute,
+                    derivation_path=drv_path,
+                    name=name,
+                    metadata=meta,
+                    system=system,
+                    parent_evaluation=evaluation,
+                )
+
+        proposal = models.CVEDerivationClusterProposal.objects.create(
+            cve=cve,
+            status=validated_data["status"],
+            rejection_reason=validated_data.get("rejection_reason"),
+            comment=validated_data.get("comment"),
+            rejection_match_count=validated_data.get("rejection_match_count"),
+            rejection_max_matches_limit=validated_data.get(
+                "rejection_max_matches_limit"
+            ),
+            algorithm_version=validated_data["algorithm_version"],
+        )
+
+        link_objs = []
+        for link_data in links_data:
+            drv_data = link_data["derivation"]
+            attribute = drv_data["attribute"]
+            name = drv_data["name"]
+            system = drv_data["system"]
+            key = derivation_as_key(
+                drv_path=_training_drv_path(
+                    attribute=attribute, name=name, system=system
+                ),
+                attr=attribute,
+                name=name,
+                meta_name=name,
+            )
+            link_objs.append(
+                models.DerivationClusterProposalLink(
+                    proposal=proposal,
+                    derivation=by_fingerprint[key],
+                    provenance_flags=link_data["provenance_flags"],
+                )
+            )
+        if link_objs:
+            models.DerivationClusterProposalLink.objects.bulk_create(link_objs)
+
+        for overlay in overlays_data:
+            models.PackageOverlay.objects.create(
+                suggestion=proposal,
+                package_attribute=overlay["package_attribute"],
+                type=overlay["type"],
+            )
+
+        return proposal

--- a/src/shared/models/linkage.py
+++ b/src/shared/models/linkage.py
@@ -61,6 +61,23 @@ class CVEDerivationClusterProposalQuerySet(models.QuerySet):
             | ~Q(status=CVEDerivationClusterProposal.Status.PENDING)
         )
 
+    def untouched(self) -> "CVEDerivationClusterProposalQuerySet":
+        """Proposals not yet touched by users or auto-triage (still pending).
+
+        Complement of :meth:`user_curated`. Useful for GC and similar code that
+        should only act on suggestions that have never left pending
+        (see also the discussion on #1211).
+        """
+        return self.filter(status=CVEDerivationClusterProposal.Status.PENDING)
+
+    def user_curated(self) -> "CVEDerivationClusterProposalQuerySet":
+        """Proposals touched by users or auto-triage (everything except pending).
+
+        Complement of :meth:`untouched`. Includes accepted, rejected (manual and
+        auto), and published suggestions used as matching training labels.
+        """
+        return self.exclude(status=CVEDerivationClusterProposal.Status.PENDING)
+
 
 @pghistory.track(
     fields=["status", "rejection_reason"],

--- a/src/shared/tests/test_matching_training_data.py
+++ b/src/shared/tests/test_matching_training_data.py
@@ -1,0 +1,258 @@
+from collections.abc import Callable
+from typing import Any, cast
+
+import pytest
+from rest_framework.exceptions import ValidationError
+
+from shared.listeners.automatic_linkage import resolve_linkage_candidates
+from shared.matching_training_data import serializers
+from shared.matching_training_data.serializers import (
+    BENCHMARK_CHANNEL_BRANCH,
+    SCHEMA_VERSION,
+    ensure_benchmark_evaluation,
+)
+from shared.models.cve import Container, CveRecord, Tag
+from shared.models.linkage import (
+    CVEDerivationClusterProposal,
+    DerivationClusterProposalLink,
+    PackageOverlay,
+    ProvenanceFlags,
+)
+from shared.models.nix_evaluation import NixChannel, NixDerivation, NixEvaluation
+
+
+def test_serializer_export_validates_like_api_payload(
+    make_container: Callable[..., Container],
+    make_suggestion: Callable[..., CVEDerivationClusterProposal],
+    make_drv: Callable[..., NixDerivation],
+) -> None:
+    """Export from fixtures, then re-validate, same path as the training-data API."""
+    foo = make_drv(pname="foo", attribute="foo")
+    foo_tests = make_drv(pname="foo-tests", attribute="foo.tests")
+    proposal = make_suggestion(
+        container=make_container(cve_id="CVE-2026-9999", package_name="foo"),
+        status=CVEDerivationClusterProposal.Status.ACCEPTED,
+        algorithm_version=1,
+        drvs={
+            foo: ProvenanceFlags.PACKAGE_NAME_MATCH,
+            foo_tests: ProvenanceFlags.PACKAGE_NAME_MATCH,
+        },
+    )
+    PackageOverlay.objects.create(
+        suggestion=proposal,
+        package_attribute="foo.tests",
+        type=PackageOverlay.Type.IGNORED,
+    )
+
+    record = serializers.CVEDerivationClusterProposal(proposal).data
+    serializer = serializers.CVEDerivationClusterProposal(data=record)
+    assert serializer.is_valid(), serializer.errors
+    validated = cast(dict[str, Any], serializer.validated_data)
+    assert validated["schema_version"] == SCHEMA_VERSION
+    assert validated["cve_id"] == "CVE-2026-9999"
+    assert len(validated["derivationclusterproposallink_set"]) == 2
+    assert validated["package_overlays"][0]["type"] == PackageOverlay.Type.IGNORED
+
+
+def test_schema_version_rejected(
+    make_container: Callable[..., Container],
+    make_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    proposal = make_suggestion(
+        container=make_container(cve_id="CVE-2026-bad-ver"),
+        status=CVEDerivationClusterProposal.Status.ACCEPTED,
+        algorithm_version=1,
+    )
+    record = dict(serializers.CVEDerivationClusterProposal(proposal).data)
+    record["schema_version"] = SCHEMA_VERSION + 1
+    serializer = serializers.CVEDerivationClusterProposal(data=record)
+    with pytest.raises(ValidationError):
+        serializer.is_valid(raise_exception=True)
+
+
+def test_user_curated_proposals_excludes_pending(
+    make_container: Callable[..., Container],
+) -> None:
+    pending_container = make_container(cve_id="CVE-2026-pend")
+    accepted_container = make_container(cve_id="CVE-2026-acc")
+
+    pending = CVEDerivationClusterProposal.objects.create(
+        cve=pending_container.cve,
+        status=CVEDerivationClusterProposal.Status.PENDING,
+        algorithm_version=1,
+    )
+    accepted = CVEDerivationClusterProposal.objects.create(
+        cve=accepted_container.cve,
+        status=CVEDerivationClusterProposal.Status.ACCEPTED,
+        algorithm_version=1,
+    )
+
+    curated_pks = set(
+        CVEDerivationClusterProposal.objects.user_curated().values_list("pk", flat=True)
+    )
+    untouched_pks = set(
+        CVEDerivationClusterProposal.objects.untouched().values_list("pk", flat=True)
+    )
+    assert pending.pk not in curated_pks
+    assert accepted.pk in curated_pks
+    assert pending.pk in untouched_pks
+    assert accepted.pk not in untouched_pks
+
+
+def test_export_import_export_roundtrip(
+    make_container: Callable[..., Container],
+    make_channel: Callable[..., NixChannel],
+    make_evaluation: Callable[..., NixEvaluation],
+    make_drv: Callable[..., NixDerivation],
+) -> None:
+    channel = make_channel(
+        channel_branch="nixos-unstable",
+        state=NixChannel.ChannelState.UNSTABLE,
+    )
+    evaluation = make_evaluation(channel=channel)
+    drv = make_drv(
+        evaluation=evaluation,
+        pname="foobar",
+        version="1.2.3",
+        attribute="foobar",
+    )
+    ignored = make_drv(
+        evaluation=evaluation,
+        pname="foobar-tests",
+        version="1.2.3",
+        attribute="foobar.tests",
+    )
+    container = make_container(
+        cve_id="CVE-2026-4242",
+        package_name="foobar",
+        product="foobar",
+        cpes=["cpe:2.3:a:example:foobar:1.2.3:*:*:*:*:*:*:*"],
+    )
+    proposal = CVEDerivationClusterProposal.objects.create(
+        cve=container.cve,
+        status=CVEDerivationClusterProposal.Status.ACCEPTED,
+        algorithm_version=CVEDerivationClusterProposal.CURRENT_ALGORITHM_VERSION,
+    )
+    DerivationClusterProposalLink.objects.create(
+        proposal=proposal,
+        derivation=drv,
+        provenance_flags=int(ProvenanceFlags.PACKAGE_NAME_MATCH),
+    )
+    DerivationClusterProposalLink.objects.create(
+        proposal=proposal,
+        derivation=ignored,
+        provenance_flags=int(ProvenanceFlags.PACKAGE_NAME_MATCH),
+    )
+    PackageOverlay.objects.create(
+        suggestion=proposal,
+        package_attribute="foobar.tests",
+        type=PackageOverlay.Type.IGNORED,
+    )
+    original = dict(serializers.CVEDerivationClusterProposal(proposal).data)
+    assert original["schema_version"] == SCHEMA_VERSION
+    assert original["cve_id"] == "CVE-2026-4242"
+    assert original["status"] == "accepted"
+    assert original["ignored_packages"] == ["foobar.tests"]
+    kept = {
+        (d["attribute"], d["name"], d["system"]) for d in original["kept_derivations"]
+    }
+    assert ("foobar", "foobar-1.2.3", "x86_64-linux") in kept
+    assert ("foobar.tests", "foobar-tests-1.2.3", "x86_64-linux") not in kept
+
+    CveRecord.objects.filter(cve_id="CVE-2026-4242").delete()
+    assert not CVEDerivationClusterProposal.objects.filter(
+        cve__cve_id="CVE-2026-4242"
+    ).exists()
+
+    serializer = serializers.CVEDerivationClusterProposal(data=original)
+    assert serializer.is_valid(), serializer.errors
+    imported = cast(CVEDerivationClusterProposal, serializer.save())
+    assert imported.cve.cve_id == "CVE-2026-4242"
+    assert imported.status == CVEDerivationClusterProposal.Status.ACCEPTED
+    assert imported.derivations.count() == 2
+    assert imported.package_overlays.filter(package_attribute="foobar.tests").exists()
+    assert NixChannel.objects.filter(channel_branch=BENCHMARK_CHANNEL_BRANCH).exists()
+
+    reexported = serializers.CVEDerivationClusterProposal(imported).data
+    assert reexported == original
+
+    imported_container = imported.cve.container.first()
+    assert imported_container is not None
+    outcome = resolve_linkage_candidates(imported_container)
+    assert outcome is not None
+
+
+def test_export_import_auto_reject_without_links(
+    make_container: Callable[..., Container],
+) -> None:
+    container = make_container(cve_id="CVE-2026-0007", package_name="zzz")
+    tag, _ = Tag.objects.get_or_create(value="exclusively-hosted-service")
+    container.tags.add(tag)
+
+    proposal = CVEDerivationClusterProposal.objects.create(
+        cve=container.cve,
+        status=CVEDerivationClusterProposal.Status.REJECTED,
+        rejection_reason=CVEDerivationClusterProposal.RejectionReason.EXCLUSIVELY_HOSTED_SERVICE,
+        algorithm_version=CVEDerivationClusterProposal.CURRENT_ALGORITHM_VERSION,
+    )
+
+    original = dict(serializers.CVEDerivationClusterProposal(proposal).data)
+    assert original["kept_derivations"] == []
+    assert original["derivationclusterproposallink_set"] == []
+    assert "exclusively-hosted-service" in original["container"]["tags"]
+
+    CveRecord.objects.filter(cve_id="CVE-2026-0007").delete()
+    serializer = serializers.CVEDerivationClusterProposal(data=original)
+    assert serializer.is_valid(), serializer.errors
+    imported = cast(CVEDerivationClusterProposal, serializer.save())
+    reexported = serializers.CVEDerivationClusterProposal(imported).data
+    assert reexported == original
+
+    imported_container = imported.cve.container.first()
+    assert imported_container is not None
+    outcome = resolve_linkage_candidates(imported_container)
+    assert outcome.rejection is not None
+    assert (
+        outcome.rejection.reason
+        == CVEDerivationClusterProposal.RejectionReason.EXCLUSIVELY_HOSTED_SERVICE
+    )
+
+
+def test_import_is_idempotent_by_cve_id(
+    make_container: Callable[..., Container],
+    make_drv: Callable[..., NixDerivation],
+) -> None:
+    container = make_container(cve_id="CVE-2026-1111", package_name="foo")
+    proposal = CVEDerivationClusterProposal.objects.create(
+        cve=container.cve,
+        status=CVEDerivationClusterProposal.Status.PUBLISHED,
+        algorithm_version=1,
+    )
+    DerivationClusterProposalLink.objects.create(
+        proposal=proposal,
+        derivation=make_drv(pname="foo", attribute="foo"),
+        provenance_flags=int(ProvenanceFlags.PACKAGE_NAME_MATCH),
+    )
+    record = serializers.CVEDerivationClusterProposal(proposal).data
+
+    first_ser = serializers.CVEDerivationClusterProposal(data=record)
+    assert first_ser.is_valid(), first_ser.errors
+    first = cast(CVEDerivationClusterProposal, first_ser.save())
+
+    second_ser = serializers.CVEDerivationClusterProposal(data=record)
+    assert second_ser.is_valid(), second_ser.errors
+    second = cast(CVEDerivationClusterProposal, second_ser.save())
+
+    assert first.pk != second.pk
+    assert (
+        CVEDerivationClusterProposal.objects.filter(cve__cve_id="CVE-2026-1111").count()
+        == 1
+    )
+
+
+def test_ensure_benchmark_evaluation_idempotency(db: None) -> None:
+    first = ensure_benchmark_evaluation()
+    second = ensure_benchmark_evaluation()
+    assert first.channel.channel_branch == BENCHMARK_CHANNEL_BRANCH
+    assert first.channel_id == second.channel_id
+    assert first.pk == second.pk


### PR DESCRIPTION
### Summary

- Add a versioned shared schema (`schema_version=1`) for matching training data (#1038)
- Export user-curated proposals (`status != pending`, including auto-rejects) to that schema
- Import records onto a synthetic `benchmark` channel so the matcher can run locally
- Roundtrip tests: export -> import -> re-export equality + `resolve_linkage_candidates` test

### Context

Staging measurement showed ~4k curated proposals / ~12k links (~8-12 MB JSON) vs a 179 GB DB. Bounded JSON + shared export/import schema is the agreed approach; `pg_dump` is out of scope here.