### PR TITLE
feat: package ignore/restore in API and new UI

### DIFF
--- a/frontend/src/components/suggestions/ActivityLog.tsx
+++ b/frontend/src/components/suggestions/ActivityLog.tsx
@@ -1,11 +1,11 @@
 import { FormatRelativeTime } from "@ark-ui/react";
 import {
-  FolderMinusIcon,
-  FolderPlusIcon,
   InboxIcon,
-  Link2Icon,
-  Link2OffIcon,
+  LinkIcon,
+  PackageMinusIcon,
+  PackagePlusIcon,
   Trash2Icon,
+  UnlinkIcon,
   UserMinusIcon,
   UserPlusIcon,
 } from "lucide-preact";
@@ -33,17 +33,13 @@ function entryIcon(entry: ActivityLogEntry) {
   }
   if (entry.action.startsWith("package.")) {
     return entry.action.includes("restore") ? (
-      <FolderPlusIcon size={size} />
+      <PackagePlusIcon size={size} />
     ) : (
-      <FolderMinusIcon size={size} />
+      <PackageMinusIcon size={size} />
     );
   }
   if (entry.action.startsWith("reference.")) {
-    return entry.action.includes("restore") ? (
-      <Link2Icon size={size} />
-    ) : (
-      <Link2OffIcon size={size} />
-    );
+    return entry.action.includes("restore") ? <LinkIcon size={size} /> : <UnlinkIcon size={size} />;
   }
   if (entry.action.startsWith("maintainer.")) {
     return entry.action.includes("add") ? (

--- a/frontend/src/components/suggestions/CategorizedMaintainersList.tsx
+++ b/frontend/src/components/suggestions/CategorizedMaintainersList.tsx
@@ -12,11 +12,15 @@ export function CategorizedMaintainersList({
   categorizedMaintainers,
   editable,
 }: Props) {
-  const { active, ignored, added } = categorizedMaintainers;
+  const { active, ignored, added, orphan } = categorizedMaintainers;
+  // Orphan maintainers (no longer associated with any active package) are kept in the data but hidden from display.
+  const orphanIds = new Set(orphan.map((m) => m.github_id));
+  const visibleActive = active.filter((m) => !orphanIds.has(m.github_id));
+  const visibleIgnored = ignored.filter((m) => !orphanIds.has(m.github_id));
   return (
     <div className="column gap" data-testid={`suggestion-${suggestionId}-maintainers`}>
       <ul className="column gap-small">
-        {active.map((m) => (
+        {visibleActive.map((m) => (
           <li key={m.github_id}>
             <Maintainer
               maintainer={m}
@@ -27,13 +31,13 @@ export function CategorizedMaintainersList({
           </li>
         ))}
       </ul>
-      {ignored.length > 0 && (
+      {visibleIgnored.length > 0 && (
         <details className="column gap">
           <summary className="text-l bold text-gray">
-            Ignored maintainers ({ignored.length})
+            Ignored maintainers ({visibleIgnored.length})
           </summary>
           <ul className="column gap-small">
-            {ignored.map((m) => (
+            {visibleIgnored.map((m) => (
               <li key={m.github_id}>
                 <Maintainer
                   maintainer={m}

--- a/frontend/src/components/suggestions/CategorizedPackagesList.tsx
+++ b/frontend/src/components/suggestions/CategorizedPackagesList.tsx
@@ -5,16 +5,29 @@ type Props = {
   suggestionId: number;
   active: SuggestionPackages;
   ignored: SuggestionPackages;
+  editable: boolean;
 };
 
-export function CategorizedPackagesList({ suggestionId, active, ignored }: Props) {
+export function CategorizedPackagesList({ suggestionId, active, ignored, editable }: Props) {
   return (
     <div className="column gap" data-testid={`suggestion-${suggestionId}-packages`}>
-      <PackagesList packages={active} />
+      <PackagesList
+        packages={active}
+        suggestionId={suggestionId}
+        editable={editable}
+        isIgnored={false}
+      />
       {Object.keys(ignored).length > 0 && (
         <details className="column gap">
-          <summary className="text-l bold text-gray">Ignored packages</summary>
-          <PackagesList packages={ignored} />
+          <summary className="text-l bold text-gray">
+            Ignored packages ({Object.keys(ignored).length})
+          </summary>
+          <PackagesList
+            packages={ignored}
+            suggestionId={suggestionId}
+            editable={editable}
+            isIgnored={true}
+          />
         </details>
       )}
     </div>

--- a/frontend/src/components/suggestions/Package.module.css
+++ b/frontend/src/components/suggestions/Package.module.css
@@ -8,5 +8,5 @@
 }
 
 .details {
-  width: 40em;
+  width: 35em;
 }

--- a/frontend/src/components/suggestions/Package.tsx
+++ b/frontend/src/components/suggestions/Package.tsx
@@ -1,9 +1,14 @@
+import { PackageMinusIcon, PackagePlusIcon } from "lucide-preact";
 import type { SuggestionPackage } from "@/api/generated/models";
+import { usePackageMutation } from "@/hooks/usePackage";
 import styles from "./Package.module.css";
 
 type Props = {
   attr: string;
   pkg: SuggestionPackage;
+  suggestionId: number;
+  editable: boolean;
+  isIgnored: boolean;
 };
 
 function versionStatusClass(status: string | null): string {
@@ -12,9 +17,29 @@ function versionStatusClass(status: string | null): string {
   return "";
 }
 
-export function Package({ attr, pkg }: Props) {
+export function Package({ attr, pkg, suggestionId, editable, isIgnored }: Props) {
+  const mutation = usePackageMutation(suggestionId);
+
+  function handleClick() {
+    mutation.mutate({
+      id: suggestionId,
+      data: { package_attribute: attr, ignored: !isIgnored },
+    });
+  }
+
   return (
     <div className={`row gap align-start wrap`}>
+      {editable && (
+        <button
+          type="button"
+          className={`btn ${isIgnored ? "btn-green" : "btn-gray"} row gap-small centered`}
+          onClick={handleClick}
+          disabled={mutation.isPending}
+        >
+          {isIgnored ? <PackagePlusIcon size="1em" /> : <PackageMinusIcon size="1em" />}
+          {isIgnored ? "Restore" : "Ignore"}
+        </button>
+      )}
       <div className="column">
         <h3 className={`bold ${styles.packageTitle}`}>{attr}</h3>
         <p className={`${styles.packageTitle}`}>{pkg.description}</p>

--- a/frontend/src/components/suggestions/PackagesList.tsx
+++ b/frontend/src/components/suggestions/PackagesList.tsx
@@ -3,14 +3,24 @@ import { Package } from "./Package";
 
 type Props = {
   packages: SuggestionPackages;
+  suggestionId: number;
+  editable: boolean;
+  isIgnored: boolean;
 };
 
-export function PackagesList({ packages }: Props) {
+export function PackagesList({ packages, suggestionId, editable, isIgnored }: Props) {
   return (
     <ul className="column dividers">
       {Object.entries(packages).map(([attr, pkg]) => (
         <li key={attr}>
-          <Package key={attr} attr={attr} pkg={pkg} />
+          <Package
+            key={attr}
+            attr={attr}
+            pkg={pkg}
+            suggestionId={suggestionId}
+            editable={editable}
+            isIgnored={isIgnored}
+          />
         </li>
       ))}
     </ul>

--- a/frontend/src/components/suggestions/Reference.tsx
+++ b/frontend/src/components/suggestions/Reference.tsx
@@ -1,4 +1,4 @@
-import { Link2Icon, Link2OffIcon } from "lucide-preact";
+import { LinkIcon, UnlinkIcon } from "lucide-preact";
 import type { SuggestionUrlReference } from "@/api/generated/models";
 import { useReferenceMutation } from "@/hooks/useReference";
 import { ReferenceTag } from "./ReferenceTag";
@@ -34,7 +34,7 @@ export function Reference({ reference, suggestionId, editable, isIgnored }: Prop
           onClick={handleClick}
           disabled={mutation.isPending}
         >
-          {isIgnored ? <Link2Icon size="1em" /> : <Link2OffIcon size="1em" />}
+          {isIgnored ? <LinkIcon size="1em" /> : <UnlinkIcon size="1em" />}
           {isIgnored ? "Restore" : "Ignore"}
         </button>
       )}

--- a/frontend/src/components/suggestions/Suggestion.tsx
+++ b/frontend/src/components/suggestions/Suggestion.tsx
@@ -84,7 +84,12 @@ export function Suggestion({ suggestion }: Props) {
       {/* Packages */}
       <div className="rounded border box column gap">
         <h2 className="text-l bold text-gray">Matching in nixpkgs</h2>
-        <CategorizedPackagesList suggestionId={id} active={packages} ignored={ignored_packages} />
+        <CategorizedPackagesList
+          suggestionId={id}
+          active={packages}
+          ignored={ignored_packages}
+          editable={userCanEdit && (status === "pending" || status === "accepted")}
+        />
       </div>
 
       {/* Maintainers */}

--- a/frontend/src/hooks/usePackage.ts
+++ b/frontend/src/hooks/usePackage.ts
@@ -1,0 +1,117 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { ApiError } from "@/api/client";
+import {
+  getGetSuggestionActivityLogQueryKey,
+  getGetSuggestionQueryKey,
+  useUpdateSuggestionPackage,
+} from "@/api/generated/endpoints";
+import type {
+  PatchedSuggestionPackageUpdate,
+  Suggestion,
+  SuggestionCategorizedMaintainers,
+  SuggestionPackages,
+} from "@/api/generated/models";
+import { getApiErrorMessage } from "@/utils/apiError";
+import { toaster } from "@/utils/toaster";
+
+type MutationVars = { id: number; data: PatchedSuggestionPackageUpdate };
+type MutationContext = { previous?: Suggestion };
+
+// TODO(@florentc): Deduplicate shared code structure between the references and maintainers counterparts
+export function usePackageMutation(suggestionId: number) {
+  const queryClient = useQueryClient();
+  const queryKey = getGetSuggestionQueryKey(suggestionId);
+
+  return useUpdateSuggestionPackage({
+    mutation: {
+      onMutate: async ({ data }: MutationVars): Promise<MutationContext> => {
+        await queryClient.cancelQueries({ queryKey });
+        const previous = queryClient.getQueryData<Suggestion>(queryKey);
+
+        queryClient.setQueryData<Suggestion>(queryKey, (prev) => {
+          if (!prev) return prev;
+          const { package_attribute, ignored } = data;
+          if (!package_attribute) return prev;
+
+          const fromKey = ignored ? "packages" : "ignored_packages";
+          const toKey = ignored ? "ignored_packages" : "packages";
+          const moving = prev[fromKey][package_attribute];
+          if (!moving) return prev;
+
+          const { [package_attribute]: _removed, ...fromRest } = prev[fromKey];
+          const newPackages = {
+            ...prev,
+            [fromKey]: fromRest,
+            [toKey]: { ...prev[toKey], [package_attribute]: moving },
+          };
+
+          // Packages moving in/out of `active` change which maintainers count as active (auto ignore/restore maintainers).
+          // The alternative is to invalidate the whole suggestion to fetch it back from the server.
+          // Doing it quickly here in the frontend makes it possible to have instant optimistic update.
+          const categorized_maintainers = recomputeCategorizedMaintainers(
+            newPackages.packages,
+            prev.categorized_maintainers,
+          );
+
+          return { ...newPackages, categorized_maintainers };
+        });
+
+        return { previous };
+      },
+      onError: (err: unknown, vars: MutationVars, context?: MutationContext) => {
+        const description = getApiErrorMessage(err);
+        if (err instanceof ApiError && err.status === 400) {
+          // Likely a stale-state conflict (e.g. another user already ignored/restored this package).
+          // The cached `previous` snapshot is stale too, so refetch instead of rolling back to it.
+          const title = vars.data.ignored ? "Package already ignored" : "Package already restored";
+          const description =
+            "The suggestion might have been stale. It has been re-synchronized with the server.";
+          queryClient.invalidateQueries({ queryKey });
+          toaster.warning({ title, description });
+        } else if (context?.previous) {
+          const title = vars.data.ignored
+            ? "Failed to ignore package"
+            : "Failed to restore package";
+          queryClient.setQueryData(queryKey, context.previous);
+          toaster.error({ title, description });
+        }
+      },
+      onSuccess: () => {
+        // A new activity log entry is created server-side.
+        // The suggestion cache is correct via the optimistic update above.
+        // We only refresh the activity log.
+        queryClient.invalidateQueries({
+          queryKey: getGetSuggestionActivityLogQueryKey(suggestionId),
+        });
+      },
+    },
+  });
+}
+
+/**
+ * Client-side port of `categorize_maintainers`
+ * Used to give instant feedback (in the maintainer section) to the user when a package is ignored/restored.
+ */
+function recomputeCategorizedMaintainers(
+  activePackages: SuggestionPackages,
+  previous: SuggestionCategorizedMaintainers,
+): SuggestionCategorizedMaintainers {
+  // Maintainers not part of an active package are not shown at all.
+  // Fits legacy UI behavior.
+  const original = [
+    ...new Map(
+      Object.values(activePackages)
+        .flatMap((pkg) => pkg.maintainers)
+        .map((m) => [m.github_id, m]),
+    ).values(),
+  ];
+
+  const previouslyIgnoredIds = new Set(previous.ignored.map((m) => m.github_id));
+
+  return {
+    original,
+    active: original.filter((m) => !previouslyIgnoredIds.has(m.github_id)),
+    ignored: original.filter((m) => previouslyIgnoredIds.has(m.github_id)),
+    added: previous.added,
+  };
+}

--- a/frontend/src/hooks/usePackage.ts
+++ b/frontend/src/hooks/usePackage.ts
@@ -96,22 +96,12 @@ function recomputeCategorizedMaintainers(
   activePackages: SuggestionPackages,
   previous: SuggestionCategorizedMaintainers,
 ): SuggestionCategorizedMaintainers {
-  // Maintainers not part of an active package are not shown at all.
-  // Fits legacy UI behavior.
-  const original = [
-    ...new Map(
-      Object.values(activePackages)
-        .flatMap((pkg) => pkg.maintainers)
-        .map((m) => [m.github_id, m]),
-    ).values(),
-  ];
-
-  const previouslyIgnoredIds = new Set(previous.ignored.map((m) => m.github_id));
+  const activePackageMaintainerIds = new Set(
+    Object.values(activePackages).flatMap((pkg) => pkg.maintainers.map((m) => m.github_id)),
+  );
 
   return {
-    original,
-    active: original.filter((m) => !previouslyIgnoredIds.has(m.github_id)),
-    ignored: original.filter((m) => previouslyIgnoredIds.has(m.github_id)),
-    added: previous.added,
+    ...previous,
+    orphan: previous.original.filter((m) => !activePackageMaintainerIds.has(m.github_id)),
   };
 }

--- a/frontend/src/routes/Home.tsx
+++ b/frontend/src/routes/Home.tsx
@@ -18,7 +18,7 @@ const doneFeatures = [
 ];
 
 const pendingFeatures = [
-  "Suggestions: package ignore/restore",
+  "Suggestions: maintainer ignore/restore",
   "Suggestions: maintainer add/delete",
   "Suggestions: status change",
   "Notification center",

--- a/src/api/suggestions/serializers.py
+++ b/src/api/suggestions/serializers.py
@@ -36,6 +36,18 @@ class SuggestionMaintainerUpdateSerializer(serializers.Serializer):
     )
 
 
+class SuggestionPackageUpdateSerializer(serializers.Serializer):
+    """Request body for ignore/restore package PATCH operations."""
+
+    package_attribute = serializers.CharField(
+        max_length=255,
+        help_text="Attribute name of the package to ignore or restore.",
+    )
+    ignored = serializers.BooleanField(
+        help_text="Set to true to ignore the package, false to restore it.",
+    )
+
+
 class SuggestionCommentSerializer(serializers.Serializer):
     """Serializer for reading or updating a suggestion comment."""
 
@@ -92,6 +104,12 @@ class SuggestionPackageSerializer(serializers.Serializer):
     derivation_ids = serializers.ListField(child=serializers.IntegerField())
     maintainers = MaintainerSerializer(many=True)
     description = serializers.CharField(allow_null=True)
+
+
+class SuggestionCategorizedPackagesSerializer(serializers.Serializer):
+    original = serializers.DictField(child=SuggestionPackageSerializer())
+    active = serializers.DictField(child=SuggestionPackageSerializer())
+    ignored = serializers.DictField(child=SuggestionPackageSerializer())
 
 
 class SuggestionAffectedProductSerializer(serializers.Serializer):

--- a/src/api/suggestions/serializers.py
+++ b/src/api/suggestions/serializers.py
@@ -137,6 +137,7 @@ class SuggestionCategorizedMaintainersSerializer(serializers.Serializer):
     active = MaintainerSerializer(many=True)
     ignored = MaintainerSerializer(many=True)
     added = MaintainerSerializer(many=True)
+    orphan = MaintainerSerializer(many=True)
 
 
 class SuggestionSerializer(serializers.Serializer):

--- a/src/api/suggestions/views.py
+++ b/src/api/suggestions/views.py
@@ -14,9 +14,11 @@ from api.serializers import ErrorDetailSerializer
 from api.suggestions.serializers import (
     ActivityLogEntrySerializer,
     SuggestionCategorizedMaintainersSerializer,
+    SuggestionCategorizedPackagesSerializer,
     SuggestionCategorizedUrlReferencesSerializer,
     SuggestionCommentSerializer,
     SuggestionMaintainerUpdateSerializer,
+    SuggestionPackageUpdateSerializer,
     SuggestionReferenceUpdateSerializer,
     SuggestionSerializer,
     folded_event_to_dict,
@@ -275,6 +277,72 @@ class SuggestionViewSet(RetrieveModelMixin, viewsets.GenericViewSet):
                     instance.ignore_maintainer(serializer.validated_data["github_id"])
                 else:
                     instance.restore_maintainer(serializer.validated_data["github_id"])
+            except ValidationError as e:
+                raise DRFValidationError(e.message_dict)
+            return Response(status=204)
+        else:
+            raise MethodNotAllowed(request.method)
+
+    @extend_schema(
+        methods=["get"],
+        operation_id="getSuggestionPackages",
+        description="Get the categorized packages of a suggestion (original, active, ignored).",
+        responses={
+            200: SuggestionCategorizedPackagesSerializer,
+            404: ErrorDetailSerializer,
+        },
+    )
+    @extend_schema(
+        methods=["patch"],
+        operation_id="updateSuggestionPackage",
+        description="Ignore or restore a package. Send `ignored: true` to ignore, `ignored: false` to restore.",
+        request=SuggestionPackageUpdateSerializer,
+        responses={
+            204: None,
+            400: ErrorDetailSerializer,
+            403: ErrorDetailSerializer,
+            404: ErrorDetailSerializer,
+        },
+    )
+    @action(
+        detail=True,
+        methods=["get", "patch"],
+        url_path="packages",
+        serializer_class=SuggestionPackageUpdateSerializer,
+    )
+    def packages(self, request: Request, pk: int) -> Response:
+        if request.method == "GET":
+            # FIXME(@florentc): On the model side, packages don't follow the "categorized" convention of maintainers and references.
+            # This converts to the convention to present a unified interface to API users.
+            # Eventually, this should be at the model level.
+            instance = self.get_object()
+            instance.ensure_fresh_cache()
+            payload = instance.cached.payload
+            active = payload["packages"]
+            data = {
+                "original": payload["original_packages"],
+                "active": active,
+                "ignored": {
+                    k: v
+                    for k, v in payload["original_packages"].items()
+                    if k not in active
+                },
+            }
+            return Response(SuggestionCategorizedPackagesSerializer(data).data)
+        elif request.method == "PATCH":
+            serializer = self.get_serializer(data=request.data)
+            serializer.is_valid(raise_exception=True)
+            instance = self.get_object()
+            instance.ensure_fresh_cache()
+            try:
+                if serializer.validated_data["ignored"]:
+                    instance.ignore_package(
+                        serializer.validated_data["package_attribute"]
+                    )
+                else:
+                    instance.restore_package(
+                        serializer.validated_data["package_attribute"]
+                    )
             except ValidationError as e:
                 raise DRFValidationError(e.message_dict)
             return Response(status=204)

--- a/src/api/tests/test_suggestion_maintainers.py
+++ b/src/api/tests/test_suggestion_maintainers.py
@@ -22,9 +22,11 @@ def test_get_maintainers_anonymous(
     assert "active" in data
     assert "ignored" in data
     assert "added" in data
+    assert "orphan" in data
     assert any(m["github_id"] == maintainer.github_id for m in data["original"])
     assert any(m["github_id"] == maintainer.github_id for m in data["active"])
     assert data["ignored"] == []
+    assert data["orphan"] == []
 
 
 def test_get_maintainers_not_found(

--- a/src/api/tests/test_suggestion_packages.py
+++ b/src/api/tests/test_suggestion_packages.py
@@ -1,0 +1,249 @@
+from collections.abc import Callable
+
+import pytest
+from django.contrib.auth.models import User
+from rest_framework.reverse import reverse
+from rest_framework.test import APIClient
+
+from shared.models.linkage import CVEDerivationClusterProposal, ProvenanceFlags
+from shared.models.nix_evaluation import NixDerivation, NixMaintainer
+
+PACKAGE_ATTRIBUTE_1 = "package1"
+PACKAGE_ATTRIBUTE_2 = "package2"
+PACKAGE_ATTRIBUTE_NON_EXISTING = "foo"
+
+
+def url(id: int) -> str:
+    return reverse("cvederivationclusterproposal-packages", kwargs={"pk": id})
+
+
+@pytest.fixture
+def suggestion_with_packages(
+    make_drv: Callable[..., NixDerivation],
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> CVEDerivationClusterProposal:
+    drv1 = make_drv(pname=PACKAGE_ATTRIBUTE_1)
+    drv2 = make_drv(pname=PACKAGE_ATTRIBUTE_2)
+    return make_cached_suggestion(
+        drvs={
+            drv1: ProvenanceFlags.PACKAGE_NAME_MATCH,
+            drv2: ProvenanceFlags.PACKAGE_NAME_MATCH,
+        },
+    )
+
+
+def test_get_packages_anonymous(
+    suggestion_with_packages: CVEDerivationClusterProposal,
+) -> None:
+    client = APIClient()
+    response = client.get(url(suggestion_with_packages.pk))
+    assert response.status_code == 200
+    data = response.data
+    assert "original" in data
+    assert "active" in data
+    assert "ignored" in data
+    assert PACKAGE_ATTRIBUTE_1 in data["original"]
+    assert PACKAGE_ATTRIBUTE_1 in data["active"]
+    assert data["ignored"] == {}
+
+
+def test_get_packages_not_found(
+    suggestion_with_packages: CVEDerivationClusterProposal,
+) -> None:
+    client = APIClient()
+    response = client.get(url(suggestion_with_packages.pk + 1))
+    assert response.status_code == 404
+
+
+def test_patch_ignore_unauthenticated(
+    suggestion_with_packages: CVEDerivationClusterProposal,
+) -> None:
+    client = APIClient()
+    response = client.patch(
+        url(suggestion_with_packages.pk),
+        {"package_attribute": PACKAGE_ATTRIBUTE_1, "ignored": True},
+        format="json",
+    )
+    assert response.status_code == 401
+
+
+def test_patch_ignore_non_committer(
+    suggestion_with_packages: CVEDerivationClusterProposal,
+    user: User,
+) -> None:
+    client = APIClient()
+    client.force_login(user)
+    response = client.patch(
+        url(suggestion_with_packages.pk),
+        {"package_attribute": PACKAGE_ATTRIBUTE_1, "ignored": True},
+        format="json",
+    )
+    assert response.status_code == 403
+
+
+def test_patch_ignore_package_not_found(
+    suggestion_with_packages: CVEDerivationClusterProposal,
+    committer: User,
+) -> None:
+    client = APIClient()
+    client.force_login(committer)
+    response = client.patch(
+        url(suggestion_with_packages.pk),
+        {"package_attribute": PACKAGE_ATTRIBUTE_NON_EXISTING, "ignored": True},
+        format="json",
+    )
+    assert response.status_code == 400
+
+
+def test_patch_ignore_package_success(
+    suggestion_with_packages: CVEDerivationClusterProposal,
+    committer: User,
+) -> None:
+    client = APIClient()
+    client.force_login(committer)
+    response = client.patch(
+        url(suggestion_with_packages.pk),
+        {"package_attribute": PACKAGE_ATTRIBUTE_1, "ignored": True},
+        format="json",
+    )
+    assert response.status_code == 204
+
+    # Verify the package moved to ignored
+    get_response = client.get(url(suggestion_with_packages.pk))
+    assert get_response.status_code == 200
+    data = get_response.data
+    assert PACKAGE_ATTRIBUTE_1 not in data["active"]
+    assert PACKAGE_ATTRIBUTE_1 in data["ignored"]
+
+
+def test_patch_ignore_package_already_ignored(
+    suggestion_with_packages: CVEDerivationClusterProposal,
+    committer: User,
+) -> None:
+    client = APIClient()
+    client.force_login(committer)
+    # First ignore
+    client.patch(
+        url(suggestion_with_packages.pk),
+        {"package_attribute": PACKAGE_ATTRIBUTE_1, "ignored": True},
+        format="json",
+    )
+    # Second ignore should fail
+    response = client.patch(
+        url(suggestion_with_packages.pk),
+        {"package_attribute": PACKAGE_ATTRIBUTE_1, "ignored": True},
+        format="json",
+    )
+    assert response.status_code == 400
+
+
+def test_patch_restore_unauthenticated(
+    suggestion_with_packages: CVEDerivationClusterProposal,
+) -> None:
+    client = APIClient()
+    response = client.patch(
+        url(suggestion_with_packages.pk),
+        {"package_attribute": PACKAGE_ATTRIBUTE_1, "ignored": False},
+        format="json",
+    )
+    assert response.status_code == 401
+
+
+def test_patch_restore_non_committer(
+    suggestion_with_packages: CVEDerivationClusterProposal,
+    user: User,
+) -> None:
+    client = APIClient()
+    client.force_login(user)
+    response = client.patch(
+        url(suggestion_with_packages.pk),
+        {"package_attribute": PACKAGE_ATTRIBUTE_1, "ignored": False},
+        format="json",
+    )
+    assert response.status_code == 403
+
+
+def test_patch_restore_package_not_ignored(
+    suggestion_with_packages: CVEDerivationClusterProposal,
+    committer: User,
+) -> None:
+    client = APIClient()
+    client.force_login(committer)
+    # Not yet ignored, so restoring should fail
+    response = client.patch(
+        url(suggestion_with_packages.pk),
+        {"package_attribute": PACKAGE_ATTRIBUTE_1, "ignored": False},
+        format="json",
+    )
+    assert response.status_code == 400
+
+
+def test_patch_restore_package_success(
+    suggestion_with_packages: CVEDerivationClusterProposal,
+    committer: User,
+) -> None:
+    client = APIClient()
+    client.force_login(committer)
+    # First ignore
+    client.patch(
+        url(suggestion_with_packages.pk),
+        {"package_attribute": PACKAGE_ATTRIBUTE_1, "ignored": True},
+        format="json",
+    )
+    # Then restore
+    response = client.patch(
+        url(suggestion_with_packages.pk),
+        {"package_attribute": PACKAGE_ATTRIBUTE_1, "ignored": False},
+        format="json",
+    )
+    assert response.status_code == 204
+
+    # Verify the package is back in active
+    get_response = client.get(url(suggestion_with_packages.pk))
+    assert get_response.status_code == 200
+    data = get_response.data
+    assert PACKAGE_ATTRIBUTE_1 in data["active"]
+    assert PACKAGE_ATTRIBUTE_1 not in data["ignored"]
+
+
+def test_patch_ignore_package_updates_maintainers(
+    committer: User,
+    make_maintainer: Callable[..., NixMaintainer],
+    make_drv: Callable[..., NixDerivation],
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Ignoring the only package a maintainer is associated with ignores it in the suggestion."""
+    only_maintainer_of_package1 = make_maintainer(github_id=999, github="solo")
+    drv1 = make_drv(pname=PACKAGE_ATTRIBUTE_1, maintainer=only_maintainer_of_package1)
+    drv2 = make_drv(pname=PACKAGE_ATTRIBUTE_2)
+    suggestion = make_cached_suggestion(
+        drvs={
+            drv1: ProvenanceFlags.PACKAGE_NAME_MATCH,
+            drv2: ProvenanceFlags.PACKAGE_NAME_MATCH,
+        },
+    )
+
+    client = APIClient()
+    client.force_login(committer)
+
+    suggestion_url = reverse(
+        "cvederivationclusterproposal-detail", kwargs={"pk": suggestion.pk}
+    )
+    before = client.get(suggestion_url)
+    maintainer_github_ids_before = {
+        m["github_id"] for m in before.data["categorized_maintainers"]["active"]
+    }
+    assert only_maintainer_of_package1.github_id in maintainer_github_ids_before
+
+    response = client.patch(
+        url(suggestion.pk),
+        {"package_attribute": PACKAGE_ATTRIBUTE_1, "ignored": True},
+        format="json",
+    )
+    assert response.status_code == 204
+
+    after = client.get(suggestion_url)
+    maintainer_github_ids_after = {
+        m["github_id"] for m in after.data["categorized_maintainers"]["active"]
+    }
+    assert only_maintainer_of_package1.github_id not in maintainer_github_ids_after

--- a/src/api/tests/test_suggestion_packages.py
+++ b/src/api/tests/test_suggestion_packages.py
@@ -206,13 +206,13 @@ def test_patch_restore_package_success(
     assert PACKAGE_ATTRIBUTE_1 not in data["ignored"]
 
 
-def test_patch_ignore_package_updates_maintainers(
+def test_patch_ignore_restore_package_updates_maintainer_orphan_status(
     committer: User,
     make_maintainer: Callable[..., NixMaintainer],
     make_drv: Callable[..., NixDerivation],
     make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
 ) -> None:
-    """Ignoring the only package a maintainer is associated with ignores it in the suggestion."""
+    """Ignoring the only active package a maintainer is associated with marks them as orphan."""
     only_maintainer_of_package1 = make_maintainer(github_id=999, github="solo")
     drv1 = make_drv(pname=PACKAGE_ATTRIBUTE_1, maintainer=only_maintainer_of_package1)
     drv2 = make_drv(pname=PACKAGE_ATTRIBUTE_2)
@@ -233,7 +233,11 @@ def test_patch_ignore_package_updates_maintainers(
     maintainer_github_ids_before = {
         m["github_id"] for m in before.data["categorized_maintainers"]["active"]
     }
+    orphan_github_ids_before = {
+        m["github_id"] for m in before.data["categorized_maintainers"]["orphan"]
+    }
     assert only_maintainer_of_package1.github_id in maintainer_github_ids_before
+    assert only_maintainer_of_package1.github_id not in orphan_github_ids_before
 
     response = client.patch(
         url(suggestion.pk),
@@ -242,8 +246,95 @@ def test_patch_ignore_package_updates_maintainers(
     )
     assert response.status_code == 204
 
-    after = client.get(suggestion_url)
-    maintainer_github_ids_after = {
-        m["github_id"] for m in after.data["categorized_maintainers"]["active"]
+    after_ignore = client.get(suggestion_url)
+    # The maintainer stays in `active` (it was never itself ignored)...
+    maintainer_github_ids_after_ignore = {
+        m["github_id"] for m in after_ignore.data["categorized_maintainers"]["active"]
     }
-    assert only_maintainer_of_package1.github_id not in maintainer_github_ids_after
+    assert only_maintainer_of_package1.github_id in maintainer_github_ids_after_ignore
+    # ...but becomes orphan since it no longer has any active package.
+    orphan_github_ids_after_ignore = {
+        m["github_id"] for m in after_ignore.data["categorized_maintainers"]["orphan"]
+    }
+    assert only_maintainer_of_package1.github_id in orphan_github_ids_after_ignore
+
+    # Restoring the package clears the orphan status.
+    response = client.patch(
+        url(suggestion.pk),
+        {"package_attribute": PACKAGE_ATTRIBUTE_1, "ignored": False},
+        format="json",
+    )
+    assert response.status_code == 204
+
+    after_restore = client.get(suggestion_url)
+    orphan_github_ids_after_restore = {
+        m["github_id"] for m in after_restore.data["categorized_maintainers"]["orphan"]
+    }
+    maintainer_github_ids_after_restore = {
+        m["github_id"] for m in after_restore.data["categorized_maintainers"]["active"]
+    }
+    assert only_maintainer_of_package1.github_id not in orphan_github_ids_after_restore
+    assert only_maintainer_of_package1.github_id in maintainer_github_ids_after_restore
+
+
+def test_restore_package_brings_back_maintainer_ignored_while_orphaned(
+    committer: User,
+    make_maintainer: Callable[..., NixMaintainer],
+    make_drv: Callable[..., NixDerivation],
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Regression test: a maintainer ignored while orphan (i.e. while their
+    last active package was ignored) must reappear in `ignored`, not
+    `active`, once that package is restored."""
+    only_maintainer_of_package1 = make_maintainer(github_id=999, github="solo")
+    drv1 = make_drv(pname=PACKAGE_ATTRIBUTE_1, maintainer=only_maintainer_of_package1)
+    drv2 = make_drv(pname=PACKAGE_ATTRIBUTE_2)
+    suggestion = make_cached_suggestion(
+        drvs={
+            drv1: ProvenanceFlags.PACKAGE_NAME_MATCH,
+            drv2: ProvenanceFlags.PACKAGE_NAME_MATCH,
+        },
+    )
+
+    client = APIClient()
+    client.force_login(committer)
+
+    suggestion_url = reverse(
+        "cvederivationclusterproposal-detail", kwargs={"pk": suggestion.pk}
+    )
+    maintainers_url = reverse(
+        "cvederivationclusterproposal-maintainers", kwargs={"pk": suggestion.pk}
+    )
+
+    # Ignore package1, its only maintainer becomes orphan.
+    response = client.patch(
+        url(suggestion.pk),
+        {"package_attribute": PACKAGE_ATTRIBUTE_1, "ignored": True},
+        format="json",
+    )
+    assert response.status_code == 204
+
+    # Ignore the (now orphan) maintainer directly.
+    response = client.patch(
+        maintainers_url,
+        {"github_id": only_maintainer_of_package1.github_id, "ignored": True},
+        format="json",
+    )
+    assert response.status_code == 204
+
+    # Restore package1: the maintainer should come back as `ignored`, not `active`.
+    response = client.patch(
+        url(suggestion.pk),
+        {"package_attribute": PACKAGE_ATTRIBUTE_1, "ignored": False},
+        format="json",
+    )
+    assert response.status_code == 204
+
+    after_restore = client.get(suggestion_url)
+    categorized = after_restore.data["categorized_maintainers"]
+    active_ids = {m["github_id"] for m in categorized["active"]}
+    ignored_ids = {m["github_id"] for m in categorized["ignored"]}
+    orphan_ids = {m["github_id"] for m in categorized["orphan"]}
+    assert only_maintainer_of_package1.github_id in ignored_ids
+    assert only_maintainer_of_package1.github_id not in active_ids
+    assert only_maintainer_of_package1.github_id not in orphan_ids

--- a/src/shared/cache_suggestions.py
+++ b/src/shared/cache_suggestions.py
@@ -97,6 +97,9 @@ class CachedSuggestion(BaseModel):
         ]  # Maintainers of original packages
         active: list["CachedSuggestion.Maintainer"]  # Non ignored original maintainers
         ignored: list["CachedSuggestion.Maintainer"]  # Ignored original maintainers
+        orphan: list[
+            "CachedSuggestion.Maintainer"
+        ]  # Maintainers of original packages who no longer have any *active* package
         added: list[
             "CachedSuggestion.Maintainer"
         ]  # Additional maintainers (not part of original maintainers)
@@ -267,7 +270,9 @@ def cache_new_suggestions(suggestion: CVEDerivationClusterProposal) -> None:
         original_packages=original_packages,
         packages=packages,
         metrics=[to_dict(m) for m in prefetched_metrics],
-        categorized_maintainers=categorize_maintainers(packages, maintainer_overlays),
+        categorized_maintainers=categorize_maintainers(
+            original_packages, packages, maintainer_overlays
+        ),
         categorized_url_references=categorize_url_references(
             suggestion.references, list(suggestion.reference_url_overlays.all())
         ),
@@ -508,19 +513,34 @@ def categorize_url_references(
 
 
 def categorize_maintainers(
-    packages: dict[str, CachedSuggestion.Package],
+    original_packages: dict[str, CachedSuggestion.Package],
+    active_packages: dict[str, CachedSuggestion.Package],
     maintainer_overlays: list[MaintainerOverlay],
 ) -> CachedSuggestion.CategorizedMaintainers:
     """
     Categorize maintainers associated to the packages of a suggestion.
+
+    `original_packages` is the full set of packages the suggestion ever had
+    (ignoring package overlays); `active_packages` is the subset that is
+    currently active (package overlays applied). `original`/`active`/`ignored`
+    are derived from `original_packages` and the maintainer overlays only, so
+    they never shrink when a package is ignored. `orphan` tracks maintainers
+    who no longer have any currently active package.
     """
-    # Collect all original maintainers from packages (deduplicated by github_id)
+    # Collect all original maintainers from all original packages (deduplicated by github_id)
     original_maintainers_dict: dict[int, CachedSuggestion.Maintainer] = {}
-    for package in packages.values():
+    for package in original_packages.values():
         for maintainer in package.maintainers:
             original_maintainers_dict[maintainer.github_id] = maintainer
 
     original_maintainers = list(original_maintainers_dict.values())
+
+    # Maintainers of currently active packages
+    active_package_maintainer_ids = {
+        maintainer.github_id
+        for package in active_packages.values()
+        for maintainer in package.maintainers
+    }
 
     # Process edits to categorize maintainers
     ignored_github_ids = set()
@@ -537,16 +557,20 @@ def categorize_maintainers(
     # Categorize original maintainers into active and ignored
     active_maintainers = []
     ignored_maintainers = []
+    orphan_maintainers = []
 
     for maintainer in original_maintainers:
         if maintainer.github_id in ignored_github_ids:
             ignored_maintainers.append(maintainer)
         else:
             active_maintainers.append(maintainer)
+        if maintainer.github_id not in active_package_maintainer_ids:
+            orphan_maintainers.append(maintainer)
 
     return CachedSuggestion.CategorizedMaintainers(
         original=original_maintainers,
         active=active_maintainers,
         ignored=ignored_maintainers,
         added=additional_maintainers,
+        orphan=orphan_maintainers,
     )

--- a/src/shared/github.py
+++ b/src/shared/github.py
@@ -76,13 +76,17 @@ def create_gh_issue(
 
     def maintainers(suggestion: CVEDerivationClusterProposal) -> str:
         raw = suggestion.cached.payload["categorized_maintainers"]
+        # Orphan maintainers no longer maintain any active package, don't ping them.
+        orphan_github_ids = {m["github_id"] for m in raw.get("orphan", [])}
         # We need to query for the latest username of each maintainer, because
         # those might have changed since they were written out in Nixpkgs; since
         # we have the user id (which is stable), we can ask the GitHub API
         maintainers_list = [
             get_maintainer_username(maintainer, github)
             for maintainer in (raw["active"] + raw["added"])
-            if "github_id" in maintainer and "github" in maintainer
+            if "github_id" in maintainer
+            and "github" in maintainer
+            and maintainer["github_id"] not in orphan_github_ids
         ]
         if maintainers_list:
             maintainers_joined = ", ".join(mention(m) for m in maintainers_list)

--- a/src/shared/models/cached.py
+++ b/src/shared/models/cached.py
@@ -20,7 +20,7 @@ class CachedSuggestions(TimeStampMixin):
 
     @classproperty
     def CURRENT_SCHEMA_VERSION(cls) -> int:  # noqa: N802, N805
-        return 4
+        return 5
 
     proposal = models.OneToOneField(
         CVEDerivationClusterProposal,

--- a/src/shared/models/linkage.py
+++ b/src/shared/models/linkage.py
@@ -230,11 +230,17 @@ class CVEDerivationClusterProposal(TimeStampMixin):
             self.cached.payload["original_packages"],
             self.package_overlays.all(),
         )
+        original_packages = {
+            k: CachedSuggestion.Package.model_validate(v)
+            for k, v in self.cached.payload["original_packages"].items()
+        }
+        active_packages = {
+            k: CachedSuggestion.Package.model_validate(v)
+            for k, v in self.cached.payload["packages"].items()
+        }
         self.cached.payload["categorized_maintainers"] = categorize_maintainers(
-            {
-                k: CachedSuggestion.Package.model_validate(v)
-                for k, v in self.cached.payload["packages"].items()
-            },
+            original_packages,
+            active_packages,
             self.maintainer_overlays.all(),
         ).model_dump()
         self.cached.save()

--- a/src/shared/models/linkage.py
+++ b/src/shared/models/linkage.py
@@ -182,20 +182,62 @@ class CVEDerivationClusterProposal(TimeStampMixin):
             cache_new_suggestions(self)
             self.refresh_from_db()
 
-    def ignore_package(self, package: str) -> None:
-        edit, created = self.package_overlays.get_or_create(
-            package_attribute=package,
-            defaults={"type": PackageOverlay.Type.IGNORED},
-        )
-        if not created and edit.type != PackageOverlay.Type.IGNORED:
-            edit.type = PackageOverlay.Type.IGNORED
-            edit.save()
-
-    def restore_package(self, package: str) -> None:
-        self.package_overlays.filter(
-            package_attribute=package,
+    def ignore_package(self, package_attribute: str) -> None:
+        """Ignore a package, updating the overlay and the cache."""
+        original_packages = self.cached.payload["original_packages"]
+        if package_attribute not in original_packages:
+            raise ValidationError(
+                {"package_attribute": "Package not found in the suggestion"}
+            )
+        if self.package_overlays.filter(
+            package_attribute=package_attribute,
             type=PackageOverlay.Type.IGNORED,
-        ).delete()
+        ).exists():
+            raise ValidationError({"package_attribute": "Package is already ignored"})
+
+        with transaction.atomic():
+            self.package_overlays.get_or_create(
+                package_attribute=package_attribute,
+                defaults={"type": PackageOverlay.Type.IGNORED},
+            )
+            self._recompute_package_cache()
+
+    def restore_package(self, package_attribute: str) -> None:
+        """Restore a previously ignored package."""
+        overlay = self.package_overlays.filter(
+            package_attribute=package_attribute,
+            type=PackageOverlay.Type.IGNORED,
+        ).first()
+        if not overlay:
+            raise ValidationError(
+                {"package_attribute": "No ignore overlay found for this package"}
+            )
+
+        with transaction.atomic():
+            overlay.delete()
+            self._recompute_package_cache()
+
+    def _recompute_package_cache(self) -> None:
+        """Recompute the cached `packages` and `categorized_maintainers` from
+        the current set of package overlays."""
+        from shared.cache_suggestions import (
+            CachedSuggestion,
+            apply_package_overlays,
+            categorize_maintainers,
+        )
+
+        self.cached.payload["packages"] = apply_package_overlays(
+            self.cached.payload["original_packages"],
+            self.package_overlays.all(),
+        )
+        self.cached.payload["categorized_maintainers"] = categorize_maintainers(
+            {
+                k: CachedSuggestion.Package.model_validate(v)
+                for k, v in self.cached.payload["packages"].items()
+            },
+            self.maintainer_overlays.all(),
+        ).model_dump()
+        self.cached.save()
 
     def ignore_reference(self, reference_url: str) -> None:
         """Ignore a URL reference, updating the overlay and the cache."""

--- a/src/webview/suggestions/context/types.py
+++ b/src/webview/suggestions/context/types.py
@@ -170,6 +170,12 @@ class SuggestionContext:
         ]
         frozen = self.suggestion.is_frozen
 
+        # Orphan maintainers (no longer associated with any active package)
+        # are kept in the cached data but hidden from this view.
+        orphan_github_ids = {
+            m["github_id"] for m in categorized_maintainers.get("orphan", [])
+        }
+
         active_contexts = [
             MaintainerContext(
                 maintainer=maintainer,
@@ -179,6 +185,7 @@ class SuggestionContext:
                 suggestion_id=self.suggestion.pk,
             )
             for maintainer in categorized_maintainers["active"]
+            if maintainer["github_id"] not in orphan_github_ids
         ]
 
         ignored_contexts = [
@@ -190,6 +197,7 @@ class SuggestionContext:
                 suggestion_id=self.suggestion.pk,
             )
             for maintainer in categorized_maintainers["ignored"]
+            if maintainer["github_id"] not in orphan_github_ids
         ]
 
         additional_contexts = [

--- a/src/webview/suggestions/views/packages.py
+++ b/src/webview/suggestions/views/packages.py
@@ -1,13 +1,7 @@
 from abc import ABC, abstractmethod
 
-from django.db import transaction
 from django.http import HttpRequest, HttpResponse
 
-from shared.cache_suggestions import (
-    CachedSuggestion,
-    apply_package_overlays,
-    categorize_maintainers,
-)
 from shared.models.linkage import (
     CVEDerivationClusterProposal,
 )
@@ -30,31 +24,12 @@ class PackageOperationBaseView(SuggestionContentEditBaseView, ABC):
         except self.ForbiddenOperationError as e:
             return e.response
 
-        # Validate that the package exists in the suggestion
-        if package_attr not in suggestion.cached.payload.get("original_packages", {}):
-            return self._handle_error(
-                request, suggestion_context, "Package not found in this suggestion"
-            )
-
-        # Perform the specific operation (to be implemented by subclasses)
+        # Perform the specific operation (to be implemented by subclasses).
+        # The model method validates the package exists and updates the cache
+        # (packages + categorized_maintainers) in one go.
         try:
-            with transaction.atomic():
-                self._perform_operation(suggestion, package_attr)
-                suggestion.cached.payload["packages"] = apply_package_overlays(
-                    suggestion.cached.payload["original_packages"],
-                    suggestion.package_overlays.all(),
-                )
-                suggestion.cached.payload["categorized_maintainers"] = (
-                    categorize_maintainers(
-                        {
-                            k: CachedSuggestion.Package.model_validate(v)
-                            for k, v in suggestion.cached.payload["packages"].items()
-                        },
-                        suggestion.maintainer_overlays.all(),
-                    ).model_dump()
-                )
-                suggestion.cached.save()
-                suggestion_context.suggestion.cached = suggestion.cached
+            self._perform_operation(suggestion, package_attr)
+            suggestion_context.suggestion.cached = suggestion.cached
         except Exception:
             return self._handle_error(
                 request,

--- a/src/webview/tests/ui_v2/test_suggestion_packages.py
+++ b/src/webview/tests/ui_v2/test_suggestion_packages.py
@@ -1,0 +1,192 @@
+from collections.abc import Callable
+
+import pytest
+from playwright.sync_api import Page, expect
+from pytest_django.live_server_helper import LiveServer
+
+from shared.models.linkage import CVEDerivationClusterProposal, ProvenanceFlags
+from shared.models.nix_evaluation import NixDerivation, NixMaintainer
+
+from .routes import SUGGESTION_DETAIL
+
+PACKAGE_ATTRIBUTE = "package1"
+
+
+@pytest.fixture
+def suggestion_with_package(
+    make_drv: Callable[..., NixDerivation],
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> Callable[..., CVEDerivationClusterProposal]:
+    def wrapped(**kwargs: object) -> CVEDerivationClusterProposal:
+        drv = make_drv(pname=PACKAGE_ATTRIBUTE)
+        return make_cached_suggestion(
+            drvs={drv: ProvenanceFlags.PACKAGE_NAME_MATCH}, **kwargs
+        )
+
+    return wrapped
+
+
+@pytest.mark.django_db
+def test_package_no_ignore_button_for_anonymous(
+    live_server: LiveServer,
+    page: Page,
+    suggestion_with_package: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    suggestion = suggestion_with_package()
+    page.goto(live_server.url + SUGGESTION_DETAIL + f"/{suggestion.pk}")
+    packages = page.get_by_test_id(f"suggestion-{suggestion.pk}-packages")
+    expect(packages.get_by_text(PACKAGE_ATTRIBUTE)).to_be_visible()
+    expect(packages.get_by_role("button", name="Ignore")).to_be_hidden()
+
+
+@pytest.mark.django_db
+def test_package_ignore_button_visible_for_committer(
+    live_server: LiveServer,
+    as_committer: Page,
+    suggestion_with_package: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Committers see the Ignore action for an active package on an editable suggestion."""
+    suggestion = suggestion_with_package(
+        status=CVEDerivationClusterProposal.Status.PENDING
+    )
+    as_committer.goto(live_server.url + SUGGESTION_DETAIL + f"/{suggestion.pk}")
+    packages = as_committer.get_by_test_id(f"suggestion-{suggestion.pk}-packages")
+    expect(packages.get_by_role("button", name="Ignore")).to_be_visible()
+
+
+@pytest.mark.django_db
+def test_package_ignore_button_hidden_when_suggestion_rejected(
+    live_server: LiveServer,
+    as_committer: Page,
+    suggestion_with_package: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Once a suggestion is rejected (frozen), packages can no longer be edited."""
+    suggestion = suggestion_with_package(
+        status=CVEDerivationClusterProposal.Status.REJECTED
+    )
+    as_committer.goto(live_server.url + SUGGESTION_DETAIL + f"/{suggestion.pk}")
+    packages = as_committer.get_by_test_id(f"suggestion-{suggestion.pk}-packages")
+    expect(packages.get_by_text(PACKAGE_ATTRIBUTE)).to_be_visible()
+    expect(packages.get_by_role("button", name="Ignore")).to_be_hidden()
+
+
+@pytest.mark.django_db
+def test_package_ignore_moves_to_ignored_section_and_logs_activity(
+    live_server: LiveServer,
+    as_committer: Page,
+    suggestion_with_package: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Clicking Ignore moves the package into the Ignored packages section
+    and records an activity log entry."""
+    suggestion = suggestion_with_package(
+        status=CVEDerivationClusterProposal.Status.PENDING
+    )
+    as_committer.goto(live_server.url + SUGGESTION_DETAIL + f"/{suggestion.pk}")
+    packages = as_committer.get_by_test_id(f"suggestion-{suggestion.pk}-packages")
+
+    packages.get_by_role("button", name="Ignore").click()
+
+    expect(packages.get_by_text("Ignored packages", exact=False)).to_be_visible()
+    packages.get_by_text("Ignored packages", exact=False).click()
+    expect(packages.get_by_role("button", name="Restore")).to_be_visible()
+
+    activity_log = as_committer.get_by_test_id(
+        f"suggestion-{suggestion.pk}-activity-log"
+    )
+    activity_log.locator("summary").click()
+    expect(activity_log.get_by_text("ignored package", exact=False)).to_be_visible()
+
+
+@pytest.mark.django_db
+def test_package_restore_moves_back_to_active_section(
+    live_server: LiveServer,
+    as_committer: Page,
+    suggestion_with_package: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Clicking Restore on an ignored package moves it back to the active list."""
+    suggestion = suggestion_with_package(
+        status=CVEDerivationClusterProposal.Status.PENDING
+    )
+    as_committer.goto(live_server.url + SUGGESTION_DETAIL + f"/{suggestion.pk}")
+    packages = as_committer.get_by_test_id(f"suggestion-{suggestion.pk}-packages")
+
+    packages.get_by_role("button", name="Ignore").click()
+    packages.get_by_text("Ignored packages", exact=False).click()
+    expect(packages.get_by_role("button", name="Restore")).to_be_visible()
+
+    packages.get_by_role("button", name="Restore").click()
+
+    expect(packages.get_by_role("button", name="Ignore")).to_be_visible()
+    expect(packages.get_by_text("Ignored packages", exact=False)).to_be_hidden()
+
+
+@pytest.mark.django_db
+def test_package_ignore_shows_error_toast_on_backend_mismatch(
+    live_server: LiveServer,
+    as_committer: Page,
+    suggestion_with_package: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """If the package was already ignored server-side (e.g. by another
+    committer, or a stale tab) by the time the user clicks Ignore, the
+    optimistic update is rolled back and an error message is shown."""
+    suggestion = suggestion_with_package(
+        status=CVEDerivationClusterProposal.Status.PENDING
+    )
+    as_committer.goto(live_server.url + SUGGESTION_DETAIL + f"/{suggestion.pk}")
+    packages = as_committer.get_by_test_id(f"suggestion-{suggestion.pk}-packages")
+    expect(packages.get_by_role("button", name="Ignore")).to_be_visible()
+
+    # Simulate a UI/backend mismatch
+    suggestion.ignore_package(PACKAGE_ATTRIBUTE)
+
+    packages.get_by_role("button", name="Ignore").click()
+
+    expect(as_committer.get_by_text("Package already ignored")).to_be_visible()
+    expect(
+        as_committer.get_by_text("The suggestion might have been stale.", exact=False)
+    ).to_be_visible()
+
+    # The suggestion is supposed to have been refreshed so the package should be ignored now
+    expect(packages.get_by_text("Ignored packages", exact=False)).to_be_visible()
+
+
+@pytest.mark.django_db
+def test_package_ignore_removes_solo_maintainer_from_active_list(
+    live_server: LiveServer,
+    as_committer: Page,
+    make_drv: Callable[..., NixDerivation],
+    make_maintainer: Callable[..., NixMaintainer],
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Ignoring the only package a maintainer is associated with drops it from the active maintainers.
+    Restoring the package brings it back."""
+    solo_maintainer = make_maintainer(github_id=999, github="solo")
+    other_maintainer = make_maintainer(github_id=998, github="other")
+    drv1 = make_drv(pname=PACKAGE_ATTRIBUTE, maintainer=solo_maintainer)
+    drv2 = make_drv(pname="package2", maintainer=other_maintainer)
+    suggestion = make_cached_suggestion(
+        status=CVEDerivationClusterProposal.Status.PENDING,
+        drvs={
+            drv1: ProvenanceFlags.PACKAGE_NAME_MATCH,
+            drv2: ProvenanceFlags.PACKAGE_NAME_MATCH,
+        },
+    )
+    as_committer.goto(live_server.url + SUGGESTION_DETAIL + f"/{suggestion.pk}")
+    maintainers = as_committer.get_by_test_id(f"suggestion-{suggestion.pk}-maintainers")
+    packages = as_committer.get_by_test_id(f"suggestion-{suggestion.pk}-packages")
+
+    expect(maintainers.get_by_text(f"@{solo_maintainer.github}")).to_be_visible()
+    expect(maintainers.get_by_text(f"@{other_maintainer.github}")).to_be_visible()
+
+    package1_item = packages.get_by_role("listitem").filter(has_text=PACKAGE_ATTRIBUTE)
+    package1_item.get_by_role("button", name="Ignore").click()
+
+    expect(maintainers.get_by_text(f"@{solo_maintainer.github}")).to_be_hidden()
+    expect(maintainers.get_by_text(f"@{other_maintainer.github}")).to_be_visible()
+
+    packages.get_by_text("Ignored packages", exact=False).click()
+    package1_item = packages.get_by_role("listitem").filter(has_text=PACKAGE_ATTRIBUTE)
+    package1_item.get_by_role("button", name="Restore").click()
+
+    expect(maintainers.get_by_text(f"@{solo_maintainer.github}")).to_be_visible()
+    expect(maintainers.get_by_text(f"@{other_maintainer.github}")).to_be_visible()

--- a/src/webview/tests/ui_v2/test_suggestion_packages.py
+++ b/src/webview/tests/ui_v2/test_suggestion_packages.py
@@ -190,3 +190,74 @@ def test_package_ignore_removes_solo_maintainer_from_active_list(
 
     expect(maintainers.get_by_text(f"@{solo_maintainer.github}")).to_be_visible()
     expect(maintainers.get_by_text(f"@{other_maintainer.github}")).to_be_visible()
+
+
+@pytest.mark.django_db
+def test_package_restore_brings_back_maintainer_in_ignored_section_if_it_was_ignored(
+    live_server: LiveServer,
+    as_committer: Page,
+    make_drv: Callable[..., NixDerivation],
+    make_maintainer: Callable[..., NixMaintainer],
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Regression test: a maintainer that was ignored, and later becomes an
+    orphan (all its packages get ignored), must reappear under "Ignored
+    maintainers" — not "active" — once one of its packages is restored."""
+    maintainer = make_maintainer(github_id=999, github="solo")
+    drv1 = make_drv(pname=PACKAGE_ATTRIBUTE, maintainer=maintainer)
+    drv2 = make_drv(pname="package2", maintainer=maintainer)
+    suggestion = make_cached_suggestion(
+        status=CVEDerivationClusterProposal.Status.PENDING,
+        drvs={
+            drv1: ProvenanceFlags.PACKAGE_NAME_MATCH,
+            drv2: ProvenanceFlags.PACKAGE_NAME_MATCH,
+        },
+    )
+    as_committer.goto(live_server.url + SUGGESTION_DETAIL + f"/{suggestion.pk}")
+    maintainers = as_committer.get_by_test_id(f"suggestion-{suggestion.pk}-maintainers")
+    packages = as_committer.get_by_test_id(f"suggestion-{suggestion.pk}-packages")
+
+    # Ignore the maintainer while it still has active packages.
+    maintainers.get_by_role("button", name="Ignore").click()
+    expect(maintainers.get_by_text("Ignored maintainers", exact=False)).to_be_visible()
+
+    # Ignore both of its packages, making it an orphan: it disappears entirely.
+    package1_item = packages.get_by_role("listitem").filter(has_text=PACKAGE_ATTRIBUTE)
+    package1_item.get_by_role("button", name="Ignore").click()
+    expect(packages.get_by_text("Ignored packages", exact=False)).to_be_visible()
+    packages.get_by_text("Ignored packages", exact=False).click()
+    expect(
+        packages.get_by_role("listitem")
+        .filter(has_text=PACKAGE_ATTRIBUTE)
+        .get_by_role("button", name="Restore")
+    ).to_be_visible()
+
+    package2_item = packages.get_by_role("listitem").filter(has_text="package2")
+    package2_item.get_by_role("button", name="Ignore").click()
+    expect(
+        packages.get_by_role("listitem")
+        .filter(has_text="package2")
+        .get_by_role("button", name="Restore")
+    ).to_be_visible()
+
+    # Both packages ignored: the maintainer is orphan, hidden from both the
+    # active and ignored sections (the "Ignored maintainers" accordion itself
+    # disappears, since it has no visible entries left).
+    expect(maintainers.get_by_text(f"@{maintainer.github}")).to_be_hidden()
+    expect(maintainers.get_by_text("Ignored maintainers", exact=False)).to_be_hidden()
+
+    # Restore one of the packages: the maintainer must reappear as ignored.
+    ignored_package1_item = packages.get_by_role("listitem").filter(
+        has_text=PACKAGE_ATTRIBUTE
+    )
+    ignored_package1_item.get_by_role("button", name="Restore").click()
+
+    expect(maintainers.get_by_text("Ignored maintainers", exact=False)).to_be_visible()
+    maintainers.get_by_text("Ignored maintainers", exact=False).click()
+    ignored_maintainer_item = maintainers.get_by_role("listitem").filter(
+        has_text=f"@{maintainer.github}"
+    )
+    expect(ignored_maintainer_item).to_be_visible()
+    expect(
+        ignored_maintainer_item.get_by_role("button", name="Restore")
+    ).to_be_visible()


### PR DESCRIPTION
- methods in model for package ignore/restore
    - takes cache update into account
    - removed the logic from legacy webviews
- API endpoints for packages in suggestions
    - GET returns a categorized (original/active/ignored) triplet of packages out of consistency with references and maintainers, but the model isn't like that yet for packages so there is a FIXME to remember it. GET is not used by the UI, the packages are obtained from suggestion serializers
    - PATCH follows same interface as references
    - tests
- New UI
    - Exactly the same button based ignore/restore thing as in legacy UI
    - Optimistic updates like for references (to avoid waiting for API response)
    - Optimistic updates are more complex because we also edit the maintainers (auto ignore maintainers when ignoring packages)