### PR TITLE
feat: Global error handling for "rate-limited" API error in new UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { useEffect } from "preact/hooks";
 import { Redirect, Route, Switch } from "wouter-preact";
+import { queryClient } from "@/api/queryClient";
 import { Footer } from "@/components/footer/Footer";
 import { Disclaimer } from "@/components/header/Disclaimer";
 import { HeaderBar } from "@/components/header/HeaderBar";
@@ -9,15 +10,6 @@ import { Home } from "@/routes/Home";
 import { SuggestionDetail } from "@/routes/SuggestionDetail";
 import { UserSettings } from "@/routes/UserSettings";
 import { toaster } from "@/utils/toaster";
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      staleTime: 30_000,
-      retry: 1,
-    },
-  },
-});
 
 export function App() {
   // Fallback landing page when allauth's GitHub OAuth handshake fails

--- a/frontend/src/api/queryClient.ts
+++ b/frontend/src/api/queryClient.ts
@@ -1,0 +1,35 @@
+/**
+ * Centralized QueryClient configuration.
+ */
+import { MutationCache, QueryCache, QueryClient } from "@tanstack/react-query";
+import { getApiErrorMessage, isRateLimited } from "@/utils/apiError";
+import { toaster } from "@/utils/toaster";
+
+const RATE_LIMIT_TOAST_ID = "rate-limited";
+
+/**
+ * Shows a single deduplicated by id "Too many requests" toast for 429s errors
+ */
+function notifyRateLimit(error: unknown): void {
+  if (!isRateLimited(error)) return;
+  if (toaster.isVisible(RATE_LIMIT_TOAST_ID)) return;
+
+  toaster.error({
+    id: RATE_LIMIT_TOAST_ID,
+    title: "Too many requests",
+    description: getApiErrorMessage(error),
+  });
+}
+
+export const queryClient = new QueryClient({
+  queryCache: new QueryCache({ onError: notifyRateLimit }),
+  mutationCache: new MutationCache({ onError: notifyRateLimit }),
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+      // Don't retry on 429s (rate limited)
+      // Limit to one retry otherwise
+      retry: (failureCount, error) => (isRateLimited(error) ? false : failureCount < 1),
+    },
+  },
+});

--- a/frontend/src/utils/apiError.ts
+++ b/frontend/src/utils/apiError.ts
@@ -1,6 +1,13 @@
 import { ApiError } from "@/api/client";
 
 /**
+ * Whether an error thrown by `apiFetch` is a 429 (rate limited) response.
+ */
+export function isRateLimited(error: unknown): boolean {
+  return error instanceof ApiError && error.status === 429;
+}
+
+/**
  * Extracts a human-readable message from an error thrown by `apiFetch`.
  */
 export function getApiErrorMessage(error: unknown): string {

--- a/src/webview/tests/ui_v2/test_rate_limit.py
+++ b/src/webview/tests/ui_v2/test_rate_limit.py
@@ -1,0 +1,21 @@
+from playwright.sync_api import Page, expect
+from pytest_django.live_server_helper import LiveServer
+
+from .routes import HOME
+
+
+def test_rate_limit_shows_toast(live_server: LiveServer, page: Page) -> None:
+    """A 429 response from any API request shows a rate-limit error."""
+    page.route(
+        "**/api/v1/me",
+        lambda route: route.fulfill(
+            status=429,
+            content_type="application/json",
+            body='{"detail": "Foo"}',
+        ),
+    )
+
+    # Home calls the "me" endpoint for authentication status
+    page.goto(live_server.url + HOME)
+
+    expect(page.get_by_text("Too many requests")).to_be_visible()


### PR DESCRIPTION
Note that this doesn't implement rate limiting in the API yet. It's just preparation work.