### PR TITLE
feat: status change (publication excluded) in new UI

### DIFF
--- a/frontend/src/components/header/AuthStatus.module.css
+++ b/frontend/src/components/header/AuthStatus.module.css
@@ -1,0 +1,11 @@
+.avatar {
+  outline-width: 2px;
+  outline-color: white;
+  width: 2em;
+  height: 2em;
+}
+
+.menuTrigger:hover .avatar,
+*[data-state="open"] .avatar {
+  outline-style: solid;
+}

--- a/frontend/src/components/header/AuthStatus.tsx
+++ b/frontend/src/components/header/AuthStatus.tsx
@@ -4,6 +4,7 @@ import { Avatar } from "@/components/ui/Avatar";
 import { Menu } from "@/components/ui/Menu";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { login, logout, useAuth } from "@/hooks/useAuth";
+import styles from "./AuthStatus.module.css";
 
 export function AuthStatus() {
   const { user, isAuthenticated, isLoading } = useAuth();
@@ -34,12 +35,16 @@ export function AuthStatus() {
   return (
     <Menu
       trigger={
-        <div className="row box compact centered gap-small">
+        <button
+          className={`row centered gap-small cursor-pointer text-white ${styles.menuTrigger}`}
+          type="button"
+        >
           <div>User settings</div>
-          <Avatar avatarUrl={user.avatar_url} username={user.username} />
-        </div>
+          <div className={`circle ${styles.avatar}`}>
+            <Avatar size="2em" avatarUrl={user.avatar_url} username={user.username} />
+          </div>
+        </button>
       }
-      label={user.username}
       items={[
         {
           value: "subscriptions",

--- a/frontend/src/components/suggestions/Suggestion.tsx
+++ b/frontend/src/components/suggestions/Suggestion.tsx
@@ -9,6 +9,7 @@ import { CategorizedReferencesList } from "./CategorizedReferencesList";
 import { Comment } from "./Comment";
 import { SeverityBadge } from "./SeverityBadge";
 import { SuggestionStatus } from "./SuggestionStatus";
+import { SuggestionStatusActions } from "./SuggestionStatusActions";
 
 type Props = {
   suggestion: SuggestionType;
@@ -102,6 +103,9 @@ export function Suggestion({ suggestion }: Props) {
       {/* Comment */}
       {(comment || userCanEdit) && (
         <Comment suggestionId={id} comment={comment ?? null} canEdit={userCanEdit} />
+      )}
+      {userCanEdit && (
+        <SuggestionStatusActions suggestionId={id} status={status} comment={comment} />
       )}
     </article>
   );

--- a/frontend/src/components/suggestions/SuggestionStatusActions.tsx
+++ b/frontend/src/components/suggestions/SuggestionStatusActions.tsx
@@ -1,0 +1,74 @@
+import { PenToolIcon, Trash2Icon } from "lucide-preact";
+import type { StatusEnum, SuggestionStatusRejectionReason } from "@/api/generated/models";
+import { Menu } from "@/components/ui/Menu";
+import { useSuggestionStatusMutation } from "@/hooks/useSuggestionStatus";
+
+type Props = {
+  suggestionId: number;
+  status: StatusEnum;
+  comment?: string | null;
+};
+
+export function SuggestionStatusActions({ suggestionId, status, comment }: Props) {
+  const mutation = useSuggestionStatusMutation(suggestionId);
+
+  if (status === "published") {
+    return null;
+  }
+
+  const canAccept = status === "pending" || status === "rejected";
+  const canDismiss = status === "pending" || status === "accepted";
+
+  function accept() {
+    mutation.mutate({ id: suggestionId, data: { status: "accepted" } });
+  }
+
+  function dismiss(rejectionReason: SuggestionStatusRejectionReason) {
+    mutation.mutate({
+      id: suggestionId,
+      data: { status: "rejected", rejection_reason: rejectionReason },
+    });
+  }
+
+  return (
+    <div
+      className={`${canDismiss ? "row" : "row-reverse"} gap-small centered spread`}
+      data-testid={`suggestion-${suggestionId}-status-actions`}
+    >
+      {canDismiss && (
+        <Menu
+          trigger={
+            <div className="btn btn-red row gap-small centered">
+              <Trash2Icon size="1em" />
+              Dismiss
+            </div>
+          }
+          items={[
+            {
+              value: "with-comment",
+              label: "With comment",
+              onSelect: () => dismiss(null),
+              disabled: !comment,
+            },
+            {
+              value: "not-in-nixpkgs",
+              label: "Not in nixpkgs",
+              onSelect: () => dismiss("not_in_nixpkgs"),
+            },
+          ]}
+        />
+      )}
+      {canAccept && (
+        <button
+          type="button"
+          className="btn btn-green row gap-small centered"
+          onClick={accept}
+          disabled={mutation.isPending}
+        >
+          <PenToolIcon size="1em" />
+          Accept
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/Avatar.tsx
+++ b/frontend/src/components/ui/Avatar.tsx
@@ -3,10 +3,10 @@ import { UserIcon } from "lucide-preact";
 type AvatarProps = {
   avatarUrl?: string | null;
   username?: string;
-  size?: string;
+  size: string;
 };
 
-export function Avatar({ avatarUrl, username, size = "2em" }: AvatarProps) {
+export function Avatar({ avatarUrl, username, size }: AvatarProps) {
   const style = size ? { width: size, height: size } : undefined;
   return avatarUrl ? (
     <img src={avatarUrl} alt={username ?? "avatar"} className="circle" style={style} />

--- a/frontend/src/components/ui/Menu.module.css
+++ b/frontend/src/components/ui/Menu.module.css
@@ -1,29 +1,4 @@
-/* FIXME(@florentc): Styling of the menu trigger should be decoupled from the menu itself */
-
-.trigger {
-  background: none;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-  color: inherit;
-  display: flex;
-  outline: none;
-}
-
-.trigger:hover > *,
-.trigger[data-state="open"] > * {
-  outline: 2px solid white;
-  border-radius: 99999px;
-}
-
 .content {
-  background: white;
-  color: black;
-  border: 1px solid var(--gray);
-  border-radius: 0.4em;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  padding: 0.25em 0;
-  min-width: 12em;
   z-index: 100;
   outline: none;
 }

--- a/frontend/src/components/ui/Menu.tsx
+++ b/frontend/src/components/ui/Menu.tsx
@@ -2,7 +2,6 @@ import {
   MenuContent,
   MenuItem,
   MenuItemGroup,
-  MenuItemGroupLabel,
   MenuPositioner,
   MenuRoot,
   MenuSeparator,
@@ -16,29 +15,25 @@ export type MenuItemConfig = {
   label: string;
   icon?: ComponentChildren;
   onSelect: () => void;
+  disabled?: boolean;
 };
 
 export type MenuEntry = MenuItemConfig | { type: "separator" };
 
 type MenuProps = {
   trigger: ComponentChildren;
-  label?: string;
   items: MenuEntry[];
 };
 
-export function Menu({ trigger, label, items }: MenuProps) {
+export function Menu({ trigger, items }: MenuProps) {
   return (
     <MenuRoot>
       <MenuTrigger className={styles.trigger}>{trigger}</MenuTrigger>
       <MenuPositioner>
-        <MenuContent className={styles.content}>
+        <MenuContent
+          className={`rounded border box compact shadow bg-white text-black ${styles.content}`}
+        >
           <MenuItemGroup>
-            {label && (
-              <>
-                <MenuItemGroupLabel className={styles.groupLabel}>{label}</MenuItemGroupLabel>
-                <MenuSeparator className={styles.separator} />
-              </>
-            )}
             {items.map((entry, i) =>
               "type" in entry ? (
                 <MenuSeparator key={i} className={styles.separator} />
@@ -46,8 +41,9 @@ export function Menu({ trigger, label, items }: MenuProps) {
                 <MenuItem
                   key={entry.value}
                   value={entry.value}
-                  className={`row centered gap-small ${styles.item}`}
+                  className={`row centered gap-small ${!entry.disabled && "cursor-pointer"} ${styles.item}`}
                   onSelect={entry.onSelect}
+                  disabled={entry.disabled}
                 >
                   {entry.icon}
                   {entry.label}

--- a/frontend/src/hooks/useSuggestionStatus.ts
+++ b/frontend/src/hooks/useSuggestionStatus.ts
@@ -1,0 +1,49 @@
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  getGetSuggestionActivityLogQueryKey,
+  getGetSuggestionQueryKey,
+  useChangeSuggestionStatus,
+} from "@/api/generated/endpoints";
+import type { Suggestion, SuggestionStatus as SuggestionStatusData } from "@/api/generated/models";
+import { getApiErrorMessage } from "@/utils/apiError";
+import { toaster } from "@/utils/toaster";
+
+type MutationVars = { id: number; data: SuggestionStatusData };
+type MutationContext = { previous?: Suggestion };
+
+export function useSuggestionStatusMutation(suggestionId: number) {
+  const queryClient = useQueryClient();
+  const queryKey = getGetSuggestionQueryKey(suggestionId);
+
+  return useChangeSuggestionStatus({
+    mutation: {
+      onMutate: async ({ data }: MutationVars): Promise<MutationContext> => {
+        await queryClient.cancelQueries({ queryKey });
+        const previous = queryClient.getQueryData<Suggestion>(queryKey);
+
+        queryClient.setQueryData<Suggestion>(queryKey, (prev) => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            status: data.status,
+            rejection_reason: data.status === "rejected" ? data.rejection_reason : undefined,
+          };
+        });
+
+        return { previous };
+      },
+      onError: (err: unknown, _vars: MutationVars, context?: MutationContext) => {
+        const description = getApiErrorMessage(err);
+        if (context?.previous) {
+          queryClient.setQueryData(queryKey, context.previous);
+        }
+        toaster.error({ title: "Failed to change status", description });
+      },
+      onSuccess: () => {
+        queryClient.invalidateQueries({
+          queryKey: getGetSuggestionActivityLogQueryKey(suggestionId),
+        });
+      },
+    },
+  });
+}

--- a/frontend/src/routes/Home.tsx
+++ b/frontend/src/routes/Home.tsx
@@ -15,12 +15,12 @@ const doneFeatures = [
   "Suggestions: comment edit",
   "Suggestions: reference ignore/restore",
   "Suggestions: maintainer ignore/restore",
+  "Suggestions: status change (publication excluded)",
 ];
 
 const pendingFeatures = [
   "Suggestions: package ignore/restore",
   "Suggestions: maintainer add/delete",
-  "Suggestions: status change",
   "Notification center",
   "Notification pill (in navbar)",
   "Notification polling",
@@ -29,6 +29,7 @@ const pendingFeatures = [
   "Suggestion lists: per status",
   "Suggestion lists: by package",
   "Suggestion lists: draft issue",
+  "Suggestions: publication and batch publication",
   "Navigation bar",
   "Published issues list",
   "Published issues individual page",

--- a/frontend/src/styles/utility.css
+++ b/frontend/src/styles/utility.css
@@ -53,7 +53,8 @@
   cursor: not-allowed;
 }
 
-.btn:not(:disabled):hover {
+.btn:not(:disabled):hover,
+*[data-state="open"] > .btn {
   outline-style: solid;
 }
 
@@ -73,31 +74,6 @@
   background-color: var(--red);
   outline-color: var(--red);
   color: white;
-}
-
-@keyframes pulse-outline {
-  0%,
-  100% {
-    outline-width: 2px;
-    opacity: 1;
-  }
-  50% {
-    outline-width: 4px;
-    opacity: 0.7;
-  }
-}
-
-.join.htmx-request,
-.btn.htmx-request {
-  outline-style: solid;
-  animation: pulse-outline 0.5s ease-in-out infinite;
-  pointer-events: none; /* Prevent additional clicks during request */
-}
-
-.join.htmx-request:hover,
-.btn.htmx-request:hover {
-  /* Override hover styles during request to maintain consistent animation */
-  outline-style: solid;
 }
 
 /* Grouping buttons with other widgets
@@ -232,6 +208,10 @@
 
 .text-l {
   font-size: 1.2em;
+}
+
+.text-black {
+  color: black;
 }
 
 .text-white {

--- a/src/webview/tests/ui_v2/test_suggestion_status.py
+++ b/src/webview/tests/ui_v2/test_suggestion_status.py
@@ -1,0 +1,207 @@
+from collections.abc import Callable
+
+import pytest
+from playwright.sync_api import Page, expect
+from pytest_django.live_server_helper import LiveServer
+
+from shared.models.linkage import CVEDerivationClusterProposal
+
+from .routes import SUGGESTION_DETAIL
+
+
+@pytest.mark.django_db
+def test_status_actions_hidden_for_anonymous(
+    live_server: LiveServer,
+    page: Page,
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Anonymous users can see the status but not Accept/Dismiss actions."""
+    suggestion = make_cached_suggestion(
+        status=CVEDerivationClusterProposal.Status.PENDING
+    )
+    page.goto(live_server.url + SUGGESTION_DETAIL + f"/{suggestion.pk}")
+    expect(page.get_by_text("Untriaged")).to_be_visible()
+    actions = page.get_by_test_id(f"suggestion-{suggestion.pk}-status-actions")
+    expect(actions).to_be_hidden()
+
+
+@pytest.mark.django_db
+def test_accept_and_dismiss_visible_for_committer_when_pending(
+    live_server: LiveServer,
+    as_committer: Page,
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Committers see both Accept and Dismiss for a pending suggestion."""
+    suggestion = make_cached_suggestion(
+        status=CVEDerivationClusterProposal.Status.PENDING
+    )
+    as_committer.goto(live_server.url + SUGGESTION_DETAIL + f"/{suggestion.pk}")
+    actions = as_committer.get_by_test_id(f"suggestion-{suggestion.pk}-status-actions")
+    expect(actions.get_by_role("button", name="Accept")).to_be_visible()
+    expect(actions.get_by_role("button", name="Dismiss")).to_be_visible()
+
+
+@pytest.mark.django_db
+def test_only_accept_visible_when_rejected(
+    live_server: LiveServer,
+    as_committer: Page,
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """A rejected suggestion can only be accepted, not dismissed again."""
+    suggestion = make_cached_suggestion(
+        status=CVEDerivationClusterProposal.Status.REJECTED,
+        rejection_reason=CVEDerivationClusterProposal.RejectionReason.NOT_IN_NIXPKGS,
+    )
+    as_committer.goto(live_server.url + SUGGESTION_DETAIL + f"/{suggestion.pk}")
+    actions = as_committer.get_by_test_id(f"suggestion-{suggestion.pk}-status-actions")
+    expect(actions.get_by_role("button", name="Accept")).to_be_visible()
+    expect(actions.get_by_role("button", name="Dismiss")).to_be_hidden()
+
+
+@pytest.mark.django_db
+def test_only_dismiss_visible_when_accepted(
+    live_server: LiveServer,
+    as_committer: Page,
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """An accepted suggestion can be dismissed but not "accepted" again."""
+    suggestion = make_cached_suggestion(
+        status=CVEDerivationClusterProposal.Status.ACCEPTED
+    )
+    as_committer.goto(live_server.url + SUGGESTION_DETAIL + f"/{suggestion.pk}")
+    actions = as_committer.get_by_test_id(f"suggestion-{suggestion.pk}-status-actions")
+    expect(actions.get_by_role("button", name="Accept")).to_be_hidden()
+    expect(actions.get_by_role("button", name="Dismiss")).to_be_visible()
+
+
+@pytest.mark.django_db
+def test_no_status_actions_when_published(
+    live_server: LiveServer,
+    as_committer: Page,
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """A published suggestion is frozen: no status actions are shown."""
+    suggestion = make_cached_suggestion(
+        status=CVEDerivationClusterProposal.Status.PUBLISHED
+    )
+    as_committer.goto(live_server.url + SUGGESTION_DETAIL + f"/{suggestion.pk}")
+    actions = as_committer.get_by_test_id(f"suggestion-{suggestion.pk}-status-actions")
+    expect(actions).to_be_hidden()
+
+
+@pytest.mark.django_db
+def test_accept_transitions_status_and_logs_activity(
+    live_server: LiveServer,
+    as_committer: Page,
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Clicking Accept transitions the suggestion to accepted and records an
+    activity log entry."""
+    suggestion = make_cached_suggestion(
+        status=CVEDerivationClusterProposal.Status.PENDING
+    )
+    as_committer.goto(live_server.url + SUGGESTION_DETAIL + f"/{suggestion.pk}")
+    actions = as_committer.get_by_test_id(f"suggestion-{suggestion.pk}-status-actions")
+
+    actions.get_by_role("button", name="Accept").click()
+
+    expect(as_committer.get_by_text("Accepted")).to_be_visible()
+    expect(actions.get_by_role("button", name="Accept")).to_be_hidden()
+    expect(actions.get_by_role("button", name="Dismiss")).to_be_visible()
+
+    activity_log = as_committer.get_by_test_id(
+        f"suggestion-{suggestion.pk}-activity-log"
+    )
+    activity_log.locator("summary").click()
+    expect(activity_log.get_by_text("accepted", exact=False)).to_be_visible()
+
+
+@pytest.mark.django_db
+def test_dismiss_not_in_nixpkgs_transitions_and_shows_reason(
+    live_server: LiveServer,
+    as_committer: Page,
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Dismissing with "Not in nixpkgs" transitions to rejected and shows the reason."""
+    suggestion = make_cached_suggestion(
+        status=CVEDerivationClusterProposal.Status.PENDING
+    )
+    as_committer.goto(live_server.url + SUGGESTION_DETAIL + f"/{suggestion.pk}")
+    actions = as_committer.get_by_test_id(f"suggestion-{suggestion.pk}-status-actions")
+
+    actions.get_by_role("button", name="Dismiss").click()
+    as_committer.get_by_role("menuitem", name="Not in nixpkgs").click()
+
+    expect(as_committer.get_by_text("Dismissed")).to_be_visible()
+    expect(as_committer.get_by_text("not_in_nixpkgs")).to_be_visible()
+
+
+@pytest.mark.django_db
+def test_dismiss_with_comment_disabled_without_existing_comment(
+    live_server: LiveServer,
+    as_committer: Page,
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """The "With comment" dismiss option is disabled when there is no comment yet,
+    since the backend requires either a rejection reason or a comment."""
+    suggestion = make_cached_suggestion(
+        status=CVEDerivationClusterProposal.Status.PENDING
+    )
+    as_committer.goto(live_server.url + SUGGESTION_DETAIL + f"/{suggestion.pk}")
+    actions = as_committer.get_by_test_id(f"suggestion-{suggestion.pk}-status-actions")
+
+    actions.get_by_role("button", name="Dismiss").click()
+
+    expect(as_committer.get_by_role("menuitem", name="With comment")).to_have_attribute(
+        "data-disabled", ""
+    )
+
+
+@pytest.mark.django_db
+def test_dismiss_with_comment_works_once_comment_is_set(
+    live_server: LiveServer,
+    as_committer: Page,
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """Once a comment is saved, "With comment" becomes usable and dismisses
+    without requiring a rejection reason."""
+    suggestion = make_cached_suggestion(
+        status=CVEDerivationClusterProposal.Status.PENDING
+    )
+    as_committer.goto(live_server.url + SUGGESTION_DETAIL + f"/{suggestion.pk}")
+
+    textarea = as_committer.locator("textarea")
+    textarea.fill("dismissal note")
+    expect(textarea).to_have_attribute("data-save-state", "saved")
+
+    actions = as_committer.get_by_test_id(f"suggestion-{suggestion.pk}-status-actions")
+    actions.get_by_role("button", name="Dismiss").click()
+    as_committer.get_by_role("menuitem", name="With comment").click()
+
+    expect(as_committer.get_by_text("Dismissed")).to_be_visible()
+
+
+@pytest.mark.django_db
+def test_accept_shows_error_toast_on_backend_mismatch(
+    live_server: LiveServer,
+    as_committer: Page,
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+) -> None:
+    """If the suggestion was already accepted server-side (e.g. by another
+    committer, or a stale tab) by the time the user clicks Accept, the
+    optimistic update is rolled back and an error message is shown."""
+    suggestion = make_cached_suggestion(
+        status=CVEDerivationClusterProposal.Status.PENDING
+    )
+    as_committer.goto(live_server.url + SUGGESTION_DETAIL + f"/{suggestion.pk}")
+    actions = as_committer.get_by_test_id(f"suggestion-{suggestion.pk}-status-actions")
+    expect(actions.get_by_role("button", name="Accept")).to_be_visible()
+
+    # Simulate a UI/backend mismatch
+    suggestion.change_status(status=CVEDerivationClusterProposal.Status.ACCEPTED)
+
+    actions.get_by_role("button", name="Accept").click()
+
+    expect(as_committer.get_by_text("Failed to change status")).to_be_visible()
+    # The optimistic update should have been rolled back to "pending"
+    expect(as_committer.get_by_text("Untriaged")).to_be_visible()


### PR DESCRIPTION
This implements status change (publication excluded for now) in the new UI. Status change was already in API.