### PR TITLE
feat: offline matching benchmark against training labels

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ Maps each labeled diagram component to its implementation.
 
 - [fetch_all_channels](../src/shared/management/commands/fetch_all_channels.py)
 - [ingest_delta_cve](../src/shared/management/commands/ingest_delta_cve.py)
-- [fetch_matching_training_data](../src/shared/management/commands/fetch_matching_training_data.py) / [import_matching_training_data](../src/shared/management/commands/import_matching_training_data.py) - see [Offline matching training data](./data_ingestion_and_matching.md#offline-matching-training-data)
+- [fetch_matching_training_data](../src/shared/management/commands/fetch_matching_training_data.py) / [import_matching_training_data](../src/shared/management/commands/import_matching_training_data.py) / [benchmark_matching](../src/shared/management/commands/benchmark_matching.py) - see [Offline matching training data](./data_ingestion_and_matching.md#offline-matching-training-data)
 - [Evaluate Nixpkgs](../src/shared/listeners/nix_evaluation.py)
 - [CVE matching](../src/shared/listeners/automatic_linkage.py)
 - [WSGI Django](../src/project/asgi.py) (Daphne ASGI in production)

--- a/docs/data_ingestion_and_matching.md
+++ b/docs/data_ingestion_and_matching.md
@@ -120,3 +120,18 @@ manage import_matching_training_data --input ./training-data/
 ```
 
 Re-importing the same dump is idempotent per CVE ID.
+
+Score the current matcher against those labels (read-only; does not create proposals):
+
+```console
+manage benchmark_matching
+```
+
+Reports true positives, false positives, and SNR vs kept derivations and ignored package overlays.
+Prints one line per CVE by default.
+Use `--quiet` for the summary only, and `--limit N` for a sample.
+
+> [!NOTE]
+> There is no dedicated purge command yet.
+> Imported training data is marked by a fixed training-org UUID and the synthetic `benchmark` channel.
+> For a full corpus, swapping the local database (or development VM disk image) is usually simpler than hand-deleting the graph.

--- a/src/shared/evaluation.py
+++ b/src/shared/evaluation.py
@@ -82,7 +82,9 @@ class EvaluatedAttribute(JSONWizard):
     system: str
 
     def as_key(self) -> DerivationKey:
-        """Unique dictionary key for a derivation (see :func:`derivation_as_key`)."""
+        """
+        Unique dictionary key for a derivation.
+        """
         return derivation_as_key(
             drv_path=self.drv_path,
             attr=self.attr,

--- a/src/shared/management/commands/benchmark_matching.py
+++ b/src/shared/management/commands/benchmark_matching.py
@@ -1,0 +1,76 @@
+"""
+Offline matching quality vs curated training-data labels.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pprint import pformat
+from typing import Any
+
+from django.core.management.base import BaseCommand
+
+from shared.matching_training_data.benchmark import (
+    aggregate,
+    rematch,
+    score_proposal,
+    training_corpus_queryset,
+)
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
+class Command(BaseCommand):
+    help = (
+        "Score current matching algorithm against curated training data. "
+        "Read-only: does not create proposals."
+    )
+
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument(
+            "--limit",
+            type=_positive_int,
+            default=None,
+            help="Score at most N training proposals (for smoke tests).",
+        )
+        parser.add_argument(
+            "--quiet",
+            action="store_true",
+            help="Suppress per-CVE ProposalScore lines (summary only).",
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        limit: int | None = options["limit"]
+        quiet: bool = options["quiet"]
+
+        self.stdout.write("Querying curated matching data...")
+        qs = training_corpus_queryset()
+        if limit is not None:
+            qs = qs[:limit]
+
+        scores = []
+        for i, original in enumerate(qs, start=1):
+            new_match = rematch(original)
+            score = score_proposal(original, new_match)
+            scores.append(score)
+            if not quiet:
+                self.stdout.write(pformat(score))
+            if i % 100 == 0:
+                self.stdout.write(f"Scored {i} proposals…")
+
+        report = aggregate(scores)
+        if report.proposals == 0:
+            self.stdout.write(
+                self.style.WARNING(
+                    "No training-data proposals found on the benchmark corpus. "
+                    "Import with manage import_matching_training_data first."
+                )
+            )
+            return
+
+        self.stdout.write(self.style.SUCCESS(pformat(report)))

--- a/src/shared/matching_training_data/benchmark.py
+++ b/src/shared/matching_training_data/benchmark.py
@@ -1,0 +1,171 @@
+"""
+Score matcher output against curated training-data labels.
+
+Fingerprint identity is a derivation key shared with evaluation ingestion.
+Call the linkage resolver only - do not persist new proposals.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from django.db.models import Q, QuerySet
+
+from shared.evaluation import DerivationKey, derivation_as_key
+from shared.listeners.automatic_linkage import (
+    LinkageOutcome,
+    resolve_linkage_candidates,
+)
+from shared.matching_training_data.serializers import (
+    _TRAINING_ORG_UUID,
+    BENCHMARK_CHANNEL_BRANCH,
+    pick_first_container,
+)
+from shared.models.linkage import CVEDerivationClusterProposal, PackageOverlay
+
+
+def label_sets(
+    original_match: CVEDerivationClusterProposal,
+) -> tuple[set[DerivationKey], set[str]]:
+    """
+    Return kept fingerprints and ignored package attributes for a proposal.
+    """
+    ignored = {
+        overlay.package_attribute
+        for overlay in original_match.package_overlays.all()
+        if overlay.type == PackageOverlay.Type.IGNORED
+    }
+    if original_match.status == CVEDerivationClusterProposal.Status.REJECTED:
+        return set(), ignored
+
+    kept: set[DerivationKey] = set()
+    for link in original_match.derivationclusterproposallink_set.select_related(
+        "derivation__metadata"
+    ):
+        drv = link.derivation
+        if drv.attribute in ignored:
+            continue
+        metadata = drv.metadata
+        kept.add(
+            derivation_as_key(
+                drv_path=drv.derivation_path,
+                attr=drv.attribute,
+                name=drv.name,
+                meta_name=metadata.name if metadata is not None else None,
+            )
+        )
+    return kept, ignored
+
+
+def snr(true_positives: int, false_positives: int) -> float:
+    if true_positives < 0 or false_positives < 0:
+        raise ValueError(
+            f"true_positives and false_positives must be non-negative, "
+            f"got {true_positives} and {false_positives}"
+        )
+    if false_positives > 0:
+        return true_positives / false_positives
+    if true_positives > 0:
+        return math.inf
+    return math.nan
+
+
+@dataclass(frozen=True)
+class ProposalScore:
+    cve_id: str
+    true_positives: int
+    false_positives: int
+    rejection_agree: bool
+    snr: float
+
+
+@dataclass(frozen=True)
+class AggregateReport:
+    proposals: int
+    true_positives: int
+    false_positives: int
+    rejection_agree_count: int
+    snr: float
+
+
+def rematch(original: CVEDerivationClusterProposal) -> LinkageOutcome:
+    """
+    Re-run the matcher on the CVE container from a curated training match.
+    """
+    container = pick_first_container(original)
+    if container is None:
+        return LinkageOutcome()
+    return resolve_linkage_candidates(container)
+
+
+def score_proposal(
+    original: CVEDerivationClusterProposal,
+    new_match: LinkageOutcome,
+) -> ProposalScore:
+    """
+    Compare a rematch outcome to curated labels for one training proposal.
+    """
+    kept, _ignored = label_sets(original)
+    proposed: set[DerivationKey] = set()
+    if new_match.derivations:
+        proposed = {
+            derivation_as_key(
+                drv_path=drv.derivation_path,
+                attr=drv.attribute,
+                name=drv.name,
+                meta_name=drv.metadata.name if drv.metadata is not None else None,
+            )
+            for drv in new_match.derivations
+        }
+    outcome_rejection = (
+        new_match.rejection.reason if new_match.rejection is not None else None
+    )
+
+    true_positives = len(proposed & kept)
+    false_positives = len(proposed - kept)
+    return ProposalScore(
+        cve_id=original.cve.cve_id,
+        true_positives=true_positives,
+        false_positives=false_positives,
+        rejection_agree=original.rejection_reason == outcome_rejection,
+        snr=snr(true_positives, false_positives),
+    )
+
+
+def aggregate(scores: Iterable[ProposalScore]) -> AggregateReport:
+    scores_list = list(scores)
+    true_positives = sum(s.true_positives for s in scores_list)
+    false_positives = sum(s.false_positives for s in scores_list)
+    return AggregateReport(
+        proposals=len(scores_list),
+        true_positives=true_positives,
+        false_positives=false_positives,
+        rejection_agree_count=sum(1 for s in scores_list if s.rejection_agree),
+        snr=snr(true_positives, false_positives),
+    )
+
+
+def training_corpus_queryset() -> QuerySet[CVEDerivationClusterProposal]:
+    """
+    User-curated proposals from the synthetic benchmark or training import graph.
+    """
+    return (
+        CVEDerivationClusterProposal.objects.user_curated()
+        .filter(
+            Q(
+                derivationclusterproposallink__derivation__parent_evaluation__channel__channel_branch=BENCHMARK_CHANNEL_BRANCH
+            )
+            | Q(cve__assigner__uuid=_TRAINING_ORG_UUID)
+        )
+        .distinct()
+        .select_related("cve")
+        .prefetch_related(
+            "package_overlays",
+            "derivationclusterproposallink_set__derivation",
+            "cve__container__tags",
+            "cve__container__affected__cpes",
+        )
+        .order_by("pk")
+    )

--- a/src/shared/tests/test_matching_training_data_benchmark.py
+++ b/src/shared/tests/test_matching_training_data_benchmark.py
@@ -1,0 +1,196 @@
+"""
+Tests for offline matching benchmark against training labels.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+
+from shared.evaluation import derivation_as_key
+from shared.matching_training_data import ensure_benchmark_evaluation
+from shared.matching_training_data.benchmark import (
+    AggregateReport,
+    ProposalScore,
+    aggregate,
+    label_sets,
+    rematch,
+    score_proposal,
+    snr,
+)
+from shared.models.cve import Container
+from shared.models.linkage import (
+    CVEDerivationClusterProposal,
+    DerivationClusterProposalLink,
+    PackageOverlay,
+    ProvenanceFlags,
+)
+from shared.models.nix_evaluation import NixDerivation
+
+
+def _proposal(
+    container: Container,
+    *derivations: NixDerivation,
+    status: str = CVEDerivationClusterProposal.Status.ACCEPTED,
+    rejection_reason: str | None = None,
+    ignored: tuple[str, ...] = (),
+) -> CVEDerivationClusterProposal:
+    proposal = CVEDerivationClusterProposal.objects.create(
+        cve=container.cve,
+        status=status,
+        rejection_reason=rejection_reason,
+        algorithm_version=CVEDerivationClusterProposal.CURRENT_ALGORITHM_VERSION,
+    )
+    for drv in derivations:
+        DerivationClusterProposalLink.objects.create(
+            proposal=proposal,
+            derivation=drv,
+            provenance_flags=int(ProvenanceFlags.PACKAGE_NAME_MATCH),
+        )
+    for attr in ignored:
+        PackageOverlay.objects.create(
+            suggestion=proposal,
+            package_attribute=attr,
+            type=PackageOverlay.Type.IGNORED,
+        )
+    return proposal
+
+
+def test_snr() -> None:
+    assert snr(4, 2) == 2.0
+    assert snr(1, 0) == math.inf
+    assert math.isnan(snr(0, 0))
+    with pytest.raises(ValueError, match="non-negative"):
+        snr(-1, 0)
+
+
+def test_aggregate_snr() -> None:
+    report = aggregate(
+        [
+            ProposalScore(
+                cve_id="CVE-1",
+                true_positives=2,
+                false_positives=1,
+                rejection_agree=True,
+                snr=2.0,
+            ),
+            ProposalScore(
+                cve_id="CVE-2",
+                true_positives=0,
+                false_positives=1,
+                rejection_agree=False,
+                snr=0.0,
+            ),
+        ]
+    )
+    assert report == AggregateReport(
+        proposals=2,
+        true_positives=2,
+        false_positives=2,
+        rejection_agree_count=1,
+        snr=1.0,
+    )
+
+
+def test_accepted_kept_hit(
+    make_container: Callable[..., Container],
+    make_drv: Callable[..., NixDerivation],
+) -> None:
+    pkg = "benchtpuniq"
+    drv = make_drv(pname=pkg, version="1.0", attribute=pkg)
+    container = make_container(
+        cve_id="CVE-2026-bench-tp", package_name=pkg, product=pkg
+    )
+    proposal = _proposal(container, drv)
+
+    kept, ignored = label_sets(proposal)
+    assert ignored == set()
+    metadata = drv.metadata
+    assert kept == {
+        derivation_as_key(
+            drv_path=drv.derivation_path,
+            attr=drv.attribute,
+            name=drv.name,
+            meta_name=metadata.name if metadata is not None else None,
+        )
+    }
+
+    score = score_proposal(proposal, rematch(proposal))
+    assert score.true_positives == 1
+    assert score.false_positives == 0
+    assert score.rejection_agree
+
+
+def test_ignored_overlay_counts_as_fp(
+    make_container: Callable[..., Container],
+    make_drv: Callable[..., NixDerivation],
+) -> None:
+    pkg = "benchfpuniq"
+    tests_attr = f"{pkg}.tests"
+    drv = make_drv(pname=pkg, version="1.0", attribute=pkg)
+    tests_drv = make_drv(pname=f"{pkg}-tests", version="1.0", attribute=tests_attr)
+    container = make_container(
+        cve_id="CVE-2026-bench-fp", package_name=pkg, product=pkg
+    )
+    proposal = _proposal(container, drv, tests_drv, ignored=(tests_attr,))
+
+    kept, ignored = label_sets(proposal)
+    assert ignored == {tests_attr}
+    tests_metadata = tests_drv.metadata
+    assert (
+        derivation_as_key(
+            drv_path=tests_drv.derivation_path,
+            attr=tests_drv.attribute,
+            name=tests_drv.name,
+            meta_name=tests_metadata.name if tests_metadata is not None else None,
+        )
+        not in kept
+    )
+
+    score = score_proposal(proposal, rematch(proposal))
+    assert score.true_positives == 1
+    assert score.false_positives == 1
+
+
+def test_auto_reject_empty_no_fp(
+    make_container: Callable[..., Container],
+) -> None:
+    container = make_container(
+        cve_id="CVE-2026-bench-rej",
+        package_name="zzz_no_such_bench_pkg_xyz",
+        product="zzz_no_such_bench_pkg_xyz",
+    )
+    proposal = _proposal(
+        container,
+        status=CVEDerivationClusterProposal.Status.REJECTED,
+        rejection_reason=CVEDerivationClusterProposal.RejectionReason.NO_MATCHES,
+    )
+    kept, _ = label_sets(proposal)
+    assert kept == set()
+
+    score = score_proposal(proposal, rematch(proposal))
+    assert score.true_positives == 0
+    assert score.false_positives == 0
+    assert score.rejection_agree
+
+
+def test_benchmark_matching_command_summary(
+    make_container: Callable[..., Container],
+    make_drv: Callable[..., NixDerivation],
+) -> None:
+    pkg = "benchcmduniq"
+    evaluation = ensure_benchmark_evaluation()
+    drv = make_drv(pname=pkg, version="1.0", attribute=pkg, evaluation=evaluation)
+    container = make_container(
+        cve_id="CVE-2026-bench-cmd", package_name=pkg, product=pkg
+    )
+    _proposal(container, drv)
+    out = StringIO()
+    call_command("benchmark_matching", stdout=out)
+    text = out.getvalue()
+    assert "Querying curated matching data..." in text
+    assert "true_positives" in text


### PR DESCRIPTION
## Summary

* Add `manage benchmark_matching` to score `resolve_linkage_candidates` against curated training-data labels on the synthetic `benchmark` channel (read-only; does not create proposals)
* Fingerprints are `(attribute, name, system)`; report TP, FP, SNR, and rejection-reason agreement vs `kept_derivations` / ignored package overlays
* Document as step 3 of the offline training-data workflow

Part of [#1038](https://github.com/NixOS/nix-security-tracker/issues/1038). Depends on [#1233](https://github.com/NixOS/nix-security-tracker/pull/1233) / [#1204](https://github.com/NixOS/nix-security-tracker/pull/1204) / [#1203](https://github.com/NixOS/nix-security-tracker/pull/1203).