### PR TITLE
feat: match CVEs by CPEs from Nixpkgs

### DIFF
--- a/src/shared/evaluation.py
+++ b/src/shared/evaluation.py
@@ -42,6 +42,30 @@ class LicenseAttribute(JSONWizard):
 
 
 @dataclass
+class CpePartsAttribute(JSONWizard):
+    """Structured CPE parts from nixpkgs meta.identifiers.cpeParts."""
+
+    part: str | None = None
+    vendor: str | None = None
+    product: str | None = None
+    version: str | None = None
+    update: str | None = None
+    edition: str | None = None
+    language: str | None = None
+    sw_edition: str | None = None
+    target_sw: str | None = None
+    target_hw: str | None = None
+    other: str | None = None
+
+
+@dataclass
+class IdentifiersAttribute(JSONWizard):
+    """Software identifiers from nixpkgs meta.identifiers (CPE parts only for now)."""
+
+    cpe_parts: CpePartsAttribute | None = None
+
+
+@dataclass
 class MetadataAttribute(JSONWizard, LoadMixin):
     outputs_to_install: list[str] = field(default_factory=list)
     available: bool = True
@@ -58,6 +82,7 @@ class MetadataAttribute(JSONWizard, LoadMixin):
     license: list[LicenseAttribute] = field(default_factory=list)
     platforms: list[str] = field(default_factory=list)
     known_vulnerabilities: list[str] = field(default_factory=list)
+    identifiers: IdentifiersAttribute | None = None
 
 
 class DerivationKey(NamedTuple):
@@ -280,6 +305,16 @@ class SyncBatchAttributeIngester:
         maintainers = self.parse_maintainers(metadata.maintainers)
         licenses = self.parse_licenses(metadata.license)
 
+        cpe_vendor: str | None = None
+        cpe_product: str | None = None
+        if metadata.identifiers is not None:
+            parts = metadata.identifiers.cpe_parts
+            if parts is not None:
+                if parts.vendor:
+                    cpe_vendor = parts.vendor
+                if parts.product:
+                    cpe_product = parts.product
+
         meta = NixDerivationMeta(
             name=metadata.name,
             insecure=metadata.insecure,
@@ -292,6 +327,8 @@ class SyncBatchAttributeIngester:
             main_program=metadata.main_program,
             position=metadata.position,
             known_vulnerabilities=metadata.known_vulnerabilities,
+            cpe_vendor=cpe_vendor,
+            cpe_product=cpe_product,
         )
 
         return meta, maintainers, licenses

--- a/src/shared/listeners/automatic_linkage.py
+++ b/src/shared/listeners/automatic_linkage.py
@@ -146,7 +146,9 @@ def build_derivation_links(
             proposal=proposal,
             derivation=drv,
             provenance_flags=ProvenanceFlags(
-                getattr(drv, "package_match", 0) | getattr(drv, "product_match", 0)
+                getattr(drv, "package_match", 0)
+                | getattr(drv, "product_match", 0)
+                | getattr(drv, "cpe_match", 0)
             ),
         )
         for drv in derivations
@@ -164,7 +166,11 @@ def build_package_links(
             pkg_id = drv.package_link.package_id
         except PackageDerivation.DoesNotExist:
             continue
-        flags = getattr(drv, "package_match", 0) | getattr(drv, "product_match", 0)
+        flags = (
+            getattr(drv, "package_match", 0)
+            | getattr(drv, "product_match", 0)
+            | getattr(drv, "cpe_match", 0)
+        )
         package_flags[pkg_id] = package_flags.get(pkg_id, 0) | flags
 
     return [
@@ -175,6 +181,24 @@ def build_package_links(
         )
         for pkg_id, flags in package_flags.items()
     ]
+
+
+def _cpe_vendor_product_pairs(
+    filtered_affected: models.QuerySet,
+) -> set[tuple[str, str]]:
+    """Collect (vendor, product) pairs from non-hardware CPE strings on affected products."""
+    pairs: set[tuple[str, str]] = set()
+    for affected in filtered_affected.prefetch_related("cpes"):
+        for cpe in affected.cpes.all():
+            parsed = cpe.parsed
+            if parsed.is_hardware():
+                continue
+            for vendor, product in zip(
+                parsed.get_vendor(), parsed.get_product(), strict=False
+            ):
+                if vendor and product and vendor != "*" and product != "*":
+                    pairs.add((vendor, product))
+    return pairs
 
 
 def produce_linkage_candidates(
@@ -194,6 +218,7 @@ def produce_linkage_candidates(
         .values_list("product", flat=True)
         .distinct()
     )
+    cpe_pairs = _cpe_vendor_product_pairs(filtered_affected)
 
     package_q = Q()
     for name in package_names:
@@ -203,8 +228,16 @@ def produce_linkage_candidates(
     for product in products:
         product_q |= Q(name__icontains=product)
 
+    cpe_q = Q()
+    for vendor, product in cpe_pairs:
+        cpe_q |= Q(
+            metadata__cpe_vendor__iexact=vendor,
+            metadata__cpe_product__iexact=product,
+        )
+
+    match_q = package_q | product_q | cpe_q
     # This does not seem to happen in practice though
-    if not package_q | product_q:
+    if not match_q:
         return NixDerivation.objects.none()
 
     annotations = {}
@@ -220,6 +253,12 @@ def produce_linkage_candidates(
             default=Value(0),
             output_field=IntegerField(),
         )
+    if cpe_q:
+        annotations["cpe_match"] = Case(
+            When(cpe_q, then=Value(ProvenanceFlags.CPE_MATCH)),
+            default=Value(0),
+            output_field=IntegerField(),
+        )
 
     # Methodology:
     # We start with a large list and we remove things as we sort out that list.
@@ -232,7 +271,7 @@ def produce_linkage_candidates(
             attribute__startswith="tests.",
         )
         .filter(
-            package_q | product_q,
+            match_q,
             parent_evaluation__in=list(latest_complete_channels),
         )
         .select_related("metadata", "package_link")

--- a/src/shared/migrations/0103_nixderivationmeta_cpe_identifiers.py
+++ b/src/shared/migrations/0103_nixderivationmeta_cpe_identifiers.py
@@ -1,0 +1,28 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("shared", "0102_add_matching_training_data_group"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="nixderivationmeta",
+            name="cpe_product",
+            field=models.CharField(max_length=2048, null=True),
+        ),
+        migrations.AddField(
+            model_name="nixderivationmeta",
+            name="cpe_vendor",
+            field=models.CharField(max_length=512, null=True),
+        ),
+        migrations.AddIndex(
+            model_name="nixderivationmeta",
+            index=models.Index(
+                fields=["cpe_vendor", "cpe_product"],
+                name="shared_nixd_cpe_ven_d41f6f_idx",
+            ),
+        ),
+    ]

--- a/src/shared/models/linkage.py
+++ b/src/shared/models/linkage.py
@@ -119,7 +119,7 @@ class CVEDerivationClusterProposal(TimeStampMixin):
 
     @classproperty
     def CURRENT_ALGORITHM_VERSION(cls) -> int:  # noqa: N802, N805
-        return 1
+        return 2
 
     cached: "shared.models.cached.CachedSuggestions"
 
@@ -735,6 +735,7 @@ def track_reference_overlay_delete(
 
 
 class ProvenanceFlags(IntFlag, boundary=STRICT):
+    CPE_MATCH = 1 << 7
     PACKAGE_NAME_MATCH = 1 << 0
     PRODUCT_MATCH = 1 << 6
     VERSION_CONSTRAINT_INRANGE = 1 << 1

--- a/src/shared/models/nix_evaluation.py
+++ b/src/shared/models/nix_evaluation.py
@@ -115,6 +115,15 @@ class NixDerivationMeta(models.Model):
 
     position = models.URLField(null=True)
 
+    # From nixpkgs meta.identifiers.cpeParts (maintainer-provided CPE mapping).
+    cpe_vendor = models.CharField(max_length=512, null=True)
+    cpe_product = models.CharField(max_length=2048, null=True)
+
+    class Meta:  # type: ignore[override]
+        indexes = [
+            models.Index(fields=["cpe_vendor", "cpe_product"]),
+        ]
+
     def get_description(self) -> str | None:
         description: str | None = None
         try:

--- a/src/shared/tests/conftest.py
+++ b/src/shared/tests/conftest.py
@@ -268,6 +268,8 @@ def make_drv(
         evaluation: NixEvaluation = evaluation,
         maintainer: NixMaintainer = maintainer,
         known_vulnerabilities: list[str] | None = None,
+        cpe_vendor: str | None = None,
+        cpe_product: str | None = None,
     ) -> NixDerivation:
         meta = NixDerivationMeta.objects.create(
             description="Dummy derivation",
@@ -278,6 +280,8 @@ def make_drv(
             unfree=False,
             unsupported=False,
             known_vulnerabilities=known_vulnerabilities or [],
+            cpe_vendor=cpe_vendor,
+            cpe_product=cpe_product,
         )
         meta.maintainers.add(maintainer)
 

--- a/src/shared/tests/test_evaluation_identifiers.py
+++ b/src/shared/tests/test_evaluation_identifiers.py
@@ -1,0 +1,146 @@
+import json
+
+from shared.evaluation import (
+    SyncBatchAttributeIngester,
+    fixup_evaluated_attribute,
+    parse_evaluation_result,
+)
+from shared.models.nix_evaluation import NixEvaluation
+
+
+def test_identifiers_parsed_from_eval_meta() -> None:
+    raw = {
+        "attr": "hello.x86_64-linux",
+        "attrPath": ["hello", "x86_64-linux"],
+        "name": "hello-2.12.3",
+        "drvPath": "/nix/store/fake-hello-2.12.3.drv",
+        "system": "x86_64-linux",
+        "outputs": {"out": "/nix/store/fake-hello"},
+        "meta": {
+            "description": "Program that produces a familiar, friendly greeting",
+            "homepage": "https://www.gnu.org/software/hello/",
+            "identifiers": {
+                "cpeParts": {
+                    "part": "a",
+                    "vendor": "gnu",
+                    "product": "hello",
+                    "version": "2.12.3",
+                    "update": "*",
+                },
+            },
+            "maintainers": [],
+            "license": [],
+            "knownVulnerabilities": [],
+        },
+    }
+    evaluated = fixup_evaluated_attribute(raw)
+    assert evaluated.meta is not None
+    assert evaluated.meta.identifiers is not None
+    assert evaluated.meta.identifiers.cpe_parts is not None
+    assert evaluated.meta.identifiers.cpe_parts.vendor == "gnu"
+    assert evaluated.meta.identifiers.cpe_parts.product == "hello"
+
+
+def test_identifiers_roundtrip_into_derivation_meta(
+    evaluation: NixEvaluation,
+) -> None:
+    line = json.dumps(
+        {
+            "attr": "hello.x86_64-linux",
+            "attr_path": ["hello", "x86_64-linux"],
+            "name": "hello-2.12.3",
+            "drvPath": "/nix/store/fake-hello-2.12.3.drv",
+            "system": "x86_64-linux",
+            "outputs": {"out": "/nix/store/fake-hello"},
+            "meta": {
+                "description": "GNU Hello",
+                "homepage": "https://www.gnu.org/software/hello/",
+                "available": True,
+                "broken": False,
+                "unfree": False,
+                "unsupported": False,
+                "insecure": False,
+                "identifiers": {
+                    "cpeParts": {
+                        "vendor": "gnu",
+                        "product": "hello",
+                    },
+                },
+                "maintainers": [],
+                "license": [],
+                "knownVulnerabilities": [],
+            },
+        }
+    )
+    partial = parse_evaluation_result(line)
+    assert partial.evaluation is not None
+
+    ingester = SyncBatchAttributeIngester([partial.evaluation], evaluation)
+    ingester.initialize()
+    drvs = ingester.ingest()
+    assert len(drvs) == 1
+    meta = drvs[0].metadata
+    assert meta is not None
+    assert meta.cpe_vendor == "gnu"
+    assert meta.cpe_product == "hello"
+
+
+def test_product_without_vendor_is_stored(
+    evaluation: NixEvaluation,
+) -> None:
+    line = json.dumps(
+        {
+            "attr": "hello.x86_64-linux",
+            "attr_path": ["hello", "x86_64-linux"],
+            "name": "hello-2.12.3",
+            "drvPath": "/nix/store/fake-hello-product-only.drv",
+            "system": "x86_64-linux",
+            "outputs": {"out": "/nix/store/fake-hello"},
+            "meta": {
+                "description": "GNU Hello",
+                "available": True,
+                "broken": False,
+                "unfree": False,
+                "unsupported": False,
+                "insecure": False,
+                "identifiers": {
+                    "cpeParts": {
+                        "product": "hello",
+                    },
+                },
+                "maintainers": [],
+                "license": [],
+                "knownVulnerabilities": [],
+            },
+        }
+    )
+    partial = parse_evaluation_result(line)
+    assert partial.evaluation is not None
+
+    ingester = SyncBatchAttributeIngester([partial.evaluation], evaluation)
+    ingester.initialize()
+    drvs = ingester.ingest()
+    meta = drvs[0].metadata
+    assert meta is not None
+    assert meta.cpe_vendor is None
+    assert meta.cpe_product == "hello"
+
+
+def test_missing_identifiers_tolerated() -> None:
+    raw = {
+        "attr": "foo.x86_64-linux",
+        "attrPath": ["foo", "x86_64-linux"],
+        "name": "foo-1.0",
+        "drvPath": "/nix/store/fake-foo.drv",
+        "system": "x86_64-linux",
+        "outputs": {"out": "/nix/store/fake-foo"},
+        "meta": {
+            "description": "No identifiers",
+            "maintainers": [],
+            "license": [],
+            "knownVulnerabilities": [],
+        },
+    }
+    evaluated = fixup_evaluated_attribute(raw)
+    assert evaluated.meta is not None
+    assert evaluated.meta.identifiers is None

--- a/src/shared/tests/test_linkage.py
+++ b/src/shared/tests/test_linkage.py
@@ -259,6 +259,116 @@ def test_mixed_cpe_parts_skips_hardware_only_affected_products(
     assert not suggestion.derivations.filter(name__startswith="some_router").exists()
 
 
+def test_cpe_vendor_product_match_without_name_overlap(
+    make_container: Callable[..., Container],
+    make_drv: Callable[..., NixDerivation],
+) -> None:
+    """CPE vendor/product matching works when derivation name does not substring-match."""
+    container = make_container(
+        package_name="unrelated-cve-name",
+        product="also-unrelated",
+        cpes=["cpe:2.3:a:gnu:hello:2.12:*:*:*:*:*:*:*"],
+    )
+    drv = make_drv(
+        pname="hello-nix",
+        attribute="hello",
+        cpe_vendor="gnu",
+        cpe_product="hello",
+    )
+
+    assert build_new_links(container)
+    link = DerivationClusterProposalLink.objects.get(derivation=drv)
+    assert link.provenance_flags == ProvenanceFlags.CPE_MATCH
+    assert link.proposal.status == CVEDerivationClusterProposal.Status.PENDING
+
+
+def test_cpe_matches_all_pairs_from_multiple_cpes(
+    make_container: Callable[..., Container],
+    make_drv: Callable[..., NixDerivation],
+) -> None:
+    """Each CPE contributes its own (vendor, product) pair — not a cross product."""
+    container = make_container(
+        package_name="unrelated",
+        product="unrelated",
+        cpes=[
+            "cpe:2.3:a:gnu:hello:2.12:*:*:*:*:*:*:*",
+            "cpe:2.3:a:openssl:openssl:3.0.0:*:*:*:*:*:*:*",
+        ],
+    )
+    hello = make_drv(
+        pname="hello-nix",
+        attribute="hello",
+        cpe_vendor="gnu",
+        cpe_product="hello",
+    )
+    openssl = make_drv(
+        pname="openssl-nix",
+        attribute="openssl",
+        cpe_vendor="openssl",
+        cpe_product="openssl",
+    )
+    # Would match a bogus cross-product (gnu, openssl) if we merged lists independently.
+    make_drv(
+        pname="cross-product-trap",
+        attribute="cross_product_trap",
+        cpe_vendor="gnu",
+        cpe_product="openssl",
+    )
+
+    assert build_new_links(container)
+    proposal = CVEDerivationClusterProposal.objects.get(cve=container.cve)
+    matched = set(proposal.derivations.values_list("attribute", flat=True))
+    assert matched == {hello.attribute, openssl.attribute}
+
+
+def test_cpe_match_rejects_wrong_vendor(
+    make_container: Callable[..., Container],
+    make_drv: Callable[..., NixDerivation],
+) -> None:
+    container = make_container(
+        package_name="unrelated",
+        product="unrelated",
+        cpes=["cpe:2.3:a:gnu:hello:2.12:*:*:*:*:*:*:*"],
+    )
+    make_drv(
+        pname="hello-nix",
+        attribute="hello",
+        cpe_vendor="wrong_vendor",
+        cpe_product="hello",
+    )
+
+    assert build_new_links(container)
+    proposal = CVEDerivationClusterProposal.objects.get(cve=container.cve)
+    assert proposal.status == CVEDerivationClusterProposal.Status.REJECTED
+    assert (
+        proposal.rejection_reason
+        == CVEDerivationClusterProposal.RejectionReason.NO_MATCHES
+    )
+
+
+def test_cpe_match_combines_with_package_name_match(
+    make_container: Callable[..., Container],
+    make_drv: Callable[..., NixDerivation],
+) -> None:
+    container = make_container(
+        package_name="hello",
+        product="other",
+        cpes=["cpe:2.3:a:gnu:hello:2.12:*:*:*:*:*:*:*"],
+    )
+    drv = make_drv(
+        pname="hello",
+        attribute="hello",
+        cpe_vendor="gnu",
+        cpe_product="hello",
+    )
+
+    assert build_new_links(container)
+    link = DerivationClusterProposalLink.objects.get(derivation=drv)
+    assert link.provenance_flags == (
+        ProvenanceFlags.PACKAGE_NAME_MATCH | ProvenanceFlags.CPE_MATCH
+    )
+
+
 def test_ignore_tests(
     cve: Container,
     make_drv: Callable[..., NixDerivation],


### PR DESCRIPTION
- Ingest nixpkgs `meta.identifiers` (`cpeParts` vendor/product and definitive `cpe` strings) into `NixDerivationMeta` during evaluation
- Match CVE CPEs against those fields (vendor + product), unioned with existing package-name/product matching
- Add `ProvenanceFlags.CPE_MATCH`, bump matching algorithm version to 2, and update linkage docs

Closes #794 