### PR TITLE
feat: group affected products in suggestions with tree view

### DIFF
--- a/frontend/src/components/suggestions/AffectedProductsList.tsx
+++ b/frontend/src/components/suggestions/AffectedProductsList.tsx
@@ -1,18 +1,10 @@
 import type { SuggestionAffectedProducts } from "@/api/generated/models";
-import { AffectedProduct } from "./AffectedProduct";
+import { AffectedProductsTree } from "./AffectedProductsTree";
 
 type Props = {
   affectedProducts: SuggestionAffectedProducts;
 };
 
 export function AffectedProductsList({ affectedProducts }: Props) {
-  return (
-    <ul className="column gap">
-      {Object.entries(affectedProducts).map(([name, product]) => (
-        <li key={`${name}-${product}`}>
-          <AffectedProduct product={product} />
-        </li>
-      ))}
-    </ul>
-  );
+  return <AffectedProductsTree affectedProducts={affectedProducts} />;
 }

--- a/frontend/src/components/suggestions/AffectedProductsTree.tsx
+++ b/frontend/src/components/suggestions/AffectedProductsTree.tsx
@@ -1,0 +1,87 @@
+import type {
+  SuggestionAffectedProduct,
+  SuggestionAffectedProducts,
+} from "@/api/generated/models";
+import { type TreeViewNode, TreeView } from "@/components/ui/TreeView";
+import {
+  type AffectedProductTreeNode,
+  groupAffectedProducts,
+} from "@/utils/groupAffectedProducts";
+import { useMemo } from "preact/hooks";
+import { AffectedProduct } from "./AffectedProduct";
+
+type AffectedProductTreeViewNode = TreeViewNode & {
+  product?: SuggestionAffectedProduct;
+};
+
+type Props = {
+  affectedProducts: SuggestionAffectedProducts;
+};
+
+function toTreeViewNodes(nodes: AffectedProductTreeNode[]): AffectedProductTreeViewNode[] {
+  return nodes.map((node) => {
+    if (node.type === "leaf") {
+      return {
+        value: node.id,
+        label: node.product.name,
+        product: node.product,
+      };
+    }
+
+    return {
+      value: node.id,
+      label: `${node.label} (${node.count})`,
+      children: toTreeViewNodes(node.children),
+    };
+  });
+}
+
+function collectExpandedBranches(nodes: AffectedProductTreeNode[]): string[] {
+  const expanded: string[] = [];
+
+  for (const node of nodes) {
+    if (node.type === "branch") {
+      if (node.count < 5) {
+        expanded.push(node.id);
+      }
+      expanded.push(...collectExpandedBranches(node.children));
+    }
+  }
+
+  return expanded;
+}
+
+export function AffectedProductsTree({ affectedProducts }: Props) {
+  const groupedNodes = useMemo(
+    () => groupAffectedProducts(affectedProducts),
+    [affectedProducts],
+  );
+
+  const rootNode = useMemo<AffectedProductTreeViewNode>(
+    () => ({
+      value: "affected-products-root",
+      label: "Affected products",
+      children: toTreeViewNodes(groupedNodes),
+    }),
+    [groupedNodes],
+  );
+
+  const defaultExpandedValue = useMemo(
+    () => collectExpandedBranches(groupedNodes),
+    [groupedNodes],
+  );
+
+  return (
+    <TreeView
+      rootNode={rootNode}
+      defaultExpandedValue={defaultExpandedValue}
+      renderItem={(node) => {
+        const productNode = node as AffectedProductTreeViewNode;
+        if (!productNode.product) {
+          return null;
+        }
+        return <AffectedProduct product={productNode.product} />;
+      }}
+    />
+  );
+}

--- a/frontend/src/components/ui/TreeView.module.css
+++ b/frontend/src/components/ui/TreeView.module.css
@@ -1,0 +1,37 @@
+.branchControl {
+  cursor: pointer;
+  list-style: none;
+}
+
+.branchControl:focus-visible {
+  outline: 2px solid var(--nixos-blue);
+  outline-offset: 2px;
+}
+
+.branchIndicator {
+  display: inline-flex;
+  transition: transform 0.15s ease;
+}
+
+.branchIndicator[data-state="open"] {
+  transform: rotate(90deg);
+}
+
+.branchLabel {
+  font-weight: bold;
+  color: var(--gray);
+}
+
+.branchContent {
+  margin-left: 1em;
+}
+
+.item {
+  padding: 0.1em 0;
+}
+
+.tree {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35em;
+}

--- a/frontend/src/components/ui/TreeView.tsx
+++ b/frontend/src/components/ui/TreeView.tsx
@@ -1,0 +1,99 @@
+import {
+  createTreeCollection,
+  TreeViewBranch,
+  TreeViewBranchContent,
+  TreeViewBranchControl,
+  TreeViewBranchIndicator,
+  TreeViewBranchText,
+  TreeViewItem,
+  TreeViewNodeProvider,
+  TreeViewRoot,
+  TreeViewTree,
+} from "@ark-ui/react/tree-view";
+import { ChevronRightIcon } from "lucide-preact";
+import type { ComponentChildren } from "preact";
+import { useMemo } from "preact/hooks";
+import styles from "./TreeView.module.css";
+
+export type TreeViewNode = {
+  value: string;
+  label: string;
+  children?: TreeViewNode[];
+};
+
+type TreeViewProps = {
+  rootNode: TreeViewNode;
+  defaultExpandedValue?: string[];
+  renderItem: (node: TreeViewNode) => ComponentChildren;
+  lazyMount?: boolean;
+};
+
+type TreeNodesProps = {
+  nodes: TreeViewNode[];
+  parentIndexPath: number[];
+  renderItem: (node: TreeViewNode) => ComponentChildren;
+};
+
+function TreeNodes({ nodes, parentIndexPath, renderItem }: TreeNodesProps) {
+  return (
+    <>
+      {nodes.map((node, index) => {
+        const indexPath = [...parentIndexPath, index];
+        const isBranch = (node.children?.length ?? 0) > 0;
+
+        return (
+          <TreeViewNodeProvider key={node.value} node={node} indexPath={indexPath}>
+            {isBranch ? (
+              <TreeViewBranch>
+                <TreeViewBranchControl className={`row gap-small align-center ${styles.branchControl}`}>
+                  <TreeViewBranchIndicator className={styles.branchIndicator}>
+                    <ChevronRightIcon size="1em" />
+                  </TreeViewBranchIndicator>
+                  <TreeViewBranchText className={styles.branchLabel}>{node.label}</TreeViewBranchText>
+                </TreeViewBranchControl>
+                <TreeViewBranchContent className={styles.branchContent}>
+                  <TreeNodes
+                    nodes={node.children ?? []}
+                    parentIndexPath={indexPath}
+                    renderItem={renderItem}
+                  />
+                </TreeViewBranchContent>
+              </TreeViewBranch>
+            ) : (
+              <TreeViewItem className={styles.item}>{renderItem(node)}</TreeViewItem>
+            )}
+          </TreeViewNodeProvider>
+        );
+      })}
+    </>
+  );
+}
+
+export function TreeView({
+  rootNode,
+  defaultExpandedValue = [],
+  renderItem,
+  lazyMount = true,
+}: TreeViewProps) {
+  const collection = useMemo(
+    () =>
+      createTreeCollection({
+        rootNode,
+      }),
+    [rootNode],
+  );
+
+  return (
+    <TreeViewRoot
+      collection={collection}
+      defaultExpandedValue={defaultExpandedValue}
+      lazyMount={lazyMount}
+      unmountOnExit={lazyMount}
+      className={styles.tree}
+    >
+      <TreeViewTree>
+        <TreeNodes nodes={rootNode.children ?? []} parentIndexPath={[]} renderItem={renderItem} />
+      </TreeViewTree>
+    </TreeViewRoot>
+  );
+}

--- a/frontend/src/utils/groupAffectedProducts.ts
+++ b/frontend/src/utils/groupAffectedProducts.ts
@@ -1,0 +1,123 @@
+import type {
+  SuggestionAffectedProduct,
+  SuggestionAffectedProducts,
+} from "@/api/generated/models";
+
+const CHUNK_SPLIT = /[^a-zA-Z0-9]+/;
+
+export type AffectedProductTreeLeaf = {
+  type: "leaf";
+  id: string;
+  product: SuggestionAffectedProduct;
+};
+
+export type AffectedProductTreeBranch = {
+  type: "branch";
+  id: string;
+  label: string;
+  count: number;
+  children: AffectedProductTreeNode[];
+};
+
+export type AffectedProductTreeNode = AffectedProductTreeLeaf | AffectedProductTreeBranch;
+
+type ProductEntry = {
+  fullName: string;
+  segments: string[];
+  product: SuggestionAffectedProduct;
+};
+
+function splitName(name: string): string[] {
+  return name.split(CHUNK_SPLIT).filter((segment) => segment.length > 0);
+}
+
+function countLeaves(nodes: AffectedProductTreeNode[]): number {
+  return nodes.reduce((total, node) => {
+    if (node.type === "leaf") {
+      return total + 1;
+    }
+    return total + node.count;
+  }, 0);
+}
+
+function toLeaf(entry: ProductEntry): AffectedProductTreeLeaf {
+  return {
+    type: "leaf",
+    id: entry.fullName,
+    product: entry.product,
+  };
+}
+
+function compareNodes(a: AffectedProductTreeNode, b: AffectedProductTreeNode): number {
+  const aLabel = a.type === "leaf" ? a.product.name : a.label;
+  const bLabel = b.type === "leaf" ? b.product.name : b.label;
+  return aLabel.localeCompare(bLabel);
+}
+
+function buildTree(entries: ProductEntry[], pathPrefix: string): AffectedProductTreeNode[] {
+  if (entries.length === 0) {
+    return [];
+  }
+
+  if (entries.length === 1) {
+    return [toLeaf(entries[0])];
+  }
+
+  const groupedByFirstSegment = new Map<string, ProductEntry[]>();
+  for (const entry of entries) {
+    if (entry.segments.length === 0) {
+      continue;
+    }
+    const segment = entry.segments[0];
+    const group = groupedByFirstSegment.get(segment);
+    if (group) {
+      group.push(entry);
+    } else {
+      groupedByFirstSegment.set(segment, [entry]);
+    }
+  }
+
+  let bestSegment: string | null = null;
+  let bestGroupSize = 0;
+  for (const [segment, group] of groupedByFirstSegment) {
+    if (group.length >= 2 && group.length > bestGroupSize) {
+      bestSegment = segment;
+      bestGroupSize = group.length;
+    }
+  }
+
+  if (!bestSegment) {
+    return entries.map(toLeaf).sort(compareNodes);
+  }
+
+  const branchEntries = groupedByFirstSegment.get(bestSegment) ?? [];
+  const otherEntries = entries.filter((entry) => entry.segments[0] !== bestSegment);
+  const branchId = pathPrefix ? `${pathPrefix}/${bestSegment}` : bestSegment;
+  const childEntries = branchEntries.map((entry) => ({
+    ...entry,
+    segments: entry.segments.slice(1),
+  }));
+
+  const branch: AffectedProductTreeBranch = {
+    type: "branch",
+    id: branchId,
+    label: bestSegment,
+    count: 0,
+    children: buildTree(childEntries, branchId),
+  };
+  branch.count = countLeaves(branch.children);
+
+  return [...buildTree(otherEntries, pathPrefix), branch].sort(compareNodes);
+}
+
+export function groupAffectedProducts(
+  affectedProducts: SuggestionAffectedProducts,
+): AffectedProductTreeNode[] {
+  const entries: ProductEntry[] = Object.entries(affectedProducts).map(([name, product]) => ({
+    fullName: name,
+    segments: splitName(name),
+    product,
+  }));
+
+  return buildTree(entries, "");
+}


### PR DESCRIPTION
Description: 

- Group long affected-product lists in suggestion detail views into a collapsible tree, addressing cases where dozens of related products (example: `eap8-*`) dominate the page (#1253).
- Add a frontend-only prefix-grouping heuristic: split product names on non-alphanumeric delimiters (-, ., /, …) and recursively group by the most common shared chunk (minimum group size 2).
- Render the grouped structure with a new Ark UI `TreeView` wrapper, leaf rows still use the existing `AffectedProduct` component (full names, version badges, CPE tooltips unchanged).