### PR TITLE
fix: set working directory for the service user

### DIFF
--- a/nix/configuration.nix
+++ b/nix/configuration.nix
@@ -250,6 +250,7 @@ in
     users.users.nix-security-tracker = {
       isSystemUser = true;
       group = "nix-security-tracker";
+      home = config.systemd.services.nix-security-tracker-server.serviceConfig.WorkingDirectory;
     };
     users.groups.nix-security-tracker = { };
 


### PR DESCRIPTION
This avoids a warning from IPython when launching `wst-manage shell`:

    UserWarning: IPython parent '/var/empty' is not a writable location, using a temp directory.