### PR TITLE
fix: inefficient activity log API requests from new UI

### DIFF
--- a/frontend/src/components/suggestions/ActivityLog.tsx
+++ b/frontend/src/components/suggestions/ActivityLog.tsx
@@ -1,4 +1,5 @@
 import { FormatRelativeTime } from "@ark-ui/react";
+import { useQueryClient } from "@tanstack/react-query";
 import {
   InboxIcon,
   LinkIcon,
@@ -9,7 +10,11 @@ import {
   UserMinusIcon,
   UserPlusIcon,
 } from "lucide-preact";
-import { useGetSuggestionActivityLog } from "@/api/generated/endpoints";
+import { useEffect } from "preact/hooks";
+import {
+  getGetSuggestionActivityLogQueryKey,
+  useGetSuggestionActivityLog,
+} from "@/api/generated/endpoints";
 import { type ActivityLogEntry, SuggestionStatusEnum } from "@/api/generated/models";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { Spinner } from "@/components/ui/Spinner";
@@ -24,6 +29,7 @@ const JUST_NOW_MS = 5_000;
 
 type Props = {
   suggestionId: number;
+  initialActivityLog?: readonly ActivityLogEntry[] | null;
 };
 
 function entryIcon(entry: ActivityLogEntry) {
@@ -178,8 +184,26 @@ function Timestamp({ iso }: { iso: string }) {
   );
 }
 
-export function ActivityLog({ suggestionId }: Props) {
-  const { data, isLoading, isFetching } = useGetSuggestionActivityLog(suggestionId);
+export function ActivityLog({ suggestionId, initialActivityLog }: Props) {
+  const queryClient = useQueryClient();
+
+  const { data, isLoading, isFetching } = useGetSuggestionActivityLog(suggestionId, undefined, {
+    query: {
+      // `initialData` seed the query on first mount with the activity log inlined in the parent suggestion
+      initialData: initialActivityLog ? [...initialActivityLog] : undefined,
+      // No automatic refetches unless specifically invalidated (e.g. after suggestion mutation)
+      staleTime: Infinity,
+    },
+  });
+
+  // When `initialActivityLog` changes, the component remounts and we reflect the new value in the activity log query cache.
+  useEffect(() => {
+    if (!initialActivityLog) return;
+    queryClient.setQueryData(getGetSuggestionActivityLogQueryKey(suggestionId), [
+      ...initialActivityLog,
+    ]);
+  }, [queryClient, suggestionId, initialActivityLog]);
+
   // Single shared tick driving re-renders for every Timestamp in this log,
   // instead of each Timestamp instance running its own interval.
   useTick(TICK_INTERVAL_MS);

--- a/frontend/src/components/suggestions/Suggestion.tsx
+++ b/frontend/src/components/suggestions/Suggestion.tsx
@@ -101,7 +101,7 @@ export function Suggestion({
             </a>
             {metrics.length > 0 && <SeverityBadge metrics={metrics} />}
           </div>
-          <ActivityLog suggestionId={id} />
+          <ActivityLog suggestionId={id} initialActivityLog={suggestion.activity_log} />
         </div>
 
         <details>

--- a/frontend/src/routes/Home.tsx
+++ b/frontend/src/routes/Home.tsx
@@ -28,13 +28,13 @@ const doneFeatures = [
   "Published issues list",
   "Published issues individual page",
   "Navigation bar",
+  "Suggestion lists: optimized batch activity log queries",
 ];
 
 const pendingFeatures = [
   "Suggestions: maintainer add/delete",
   "Notification center",
   "Notification pill (in navbar)",
-  "Suggestion lists: optimized batch activity log queries",
   "Suggestions: publication and batch publication",
   "Suggestions: section icons (like in tab view)",
   "Homepage",

--- a/frontend/src/routes/IssueDetail.tsx
+++ b/frontend/src/routes/IssueDetail.tsx
@@ -10,7 +10,7 @@ export function IssueDetail() {
 
   const { data, isLoading, isError, error } = useGetIssue(
     code,
-    { expand: "suggestions" },
+    { expand: "suggestions", activity_log: true },
     { query: { enabled: Boolean(code) } },
   );
 

--- a/frontend/src/routes/IssueList.tsx
+++ b/frontend/src/routes/IssueList.tsx
@@ -31,6 +31,7 @@ export function IssueList() {
   const { data, isLoading, isError, error } = useListIssues({
     page,
     expand: "suggestions",
+    activity_log: true,
   });
 
   const handlePageChange = (newPage: number) => {

--- a/frontend/src/routes/SuggestionDetail.tsx
+++ b/frontend/src/routes/SuggestionDetail.tsx
@@ -8,9 +8,11 @@ export function SuggestionDetail() {
   const params = useParams<{ id: string }>();
   const id = Number(params.id);
 
-  const { data, isLoading, isError, error } = useGetSuggestion(id, {
-    query: { enabled: !Number.isNaN(id) },
-  });
+  const { data, isLoading, isError, error } = useGetSuggestion(
+    id,
+    { activity_log: true },
+    { query: { enabled: !Number.isNaN(id) } },
+  );
 
   if (Number.isNaN(id)) {
     return <p className="rounded box bg-red-light">Invalid suggestion ID.</p>;

--- a/frontend/src/routes/SuggestionList.tsx
+++ b/frontend/src/routes/SuggestionList.tsx
@@ -52,6 +52,7 @@ export function SuggestionList() {
     status: filters.statuses.length > 0 ? filters.statuses : undefined,
     in_issue_draft: filters.inIssueDraft || undefined,
     package: filters.packageFilter || undefined,
+    activity_log: true,
   });
 
   const handlePageChange = (newPage: number) => {

--- a/frontend/src/utils/suggestionCache.ts
+++ b/frontend/src/utils/suggestionCache.ts
@@ -10,9 +10,18 @@ import type { PaginatedSuggestionList, Suggestion } from "@/api/generated/models
 
 const listQueryKeyPrefix = getListSuggestionsQueryKey();
 
+// Common query key prefix regardless of query params (e.g. activity log)
+function detailQueryKeyPrefix(id: number) {
+  return getGetSuggestionQueryKey(id);
+}
+
 export function getCachedSuggestion(queryClient: QueryClient, id: number): Suggestion | undefined {
-  const detail = queryClient.getQueryData<Suggestion>(getGetSuggestionQueryKey(id));
-  if (detail) return detail;
+  const detailQueries = queryClient.getQueriesData<Suggestion>({
+    queryKey: detailQueryKeyPrefix(id),
+  });
+  for (const [, data] of detailQueries) {
+    if (data) return data;
+  }
 
   const listQueries = queryClient.getQueriesData<PaginatedSuggestionList>({
     queryKey: listQueryKeyPrefix,
@@ -30,7 +39,7 @@ export async function cancelCachedSuggestionQueries(
   id: number,
 ): Promise<void> {
   await Promise.all([
-    queryClient.cancelQueries({ queryKey: getGetSuggestionQueryKey(id) }),
+    queryClient.cancelQueries({ queryKey: detailQueryKeyPrefix(id) }),
     queryClient.cancelQueries({ queryKey: listQueryKeyPrefix }),
   ]);
 }
@@ -40,7 +49,7 @@ export function setCachedSuggestion(
   id: number,
   updater: (prev: Suggestion) => Suggestion,
 ): void {
-  queryClient.setQueryData<Suggestion>(getGetSuggestionQueryKey(id), (prev) =>
+  queryClient.setQueriesData<Suggestion>({ queryKey: detailQueryKeyPrefix(id) }, (prev) =>
     prev ? updater(prev) : prev,
   );
 
@@ -57,6 +66,6 @@ export function setCachedSuggestion(
 }
 
 export function invalidateCachedSuggestion(queryClient: QueryClient, id: number): void {
-  queryClient.invalidateQueries({ queryKey: getGetSuggestionQueryKey(id) });
+  queryClient.invalidateQueries({ queryKey: detailQueryKeyPrefix(id) });
   queryClient.invalidateQueries({ queryKey: listQueryKeyPrefix });
 }

--- a/src/api/issues/views.py
+++ b/src/api/issues/views.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 from django.db.models import Prefetch
 from django.db.models.query import QuerySet
 from drf_spectacular.utils import OpenApiParameter, extend_schema
@@ -9,7 +11,9 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from api.issues.serializers import IssueSerializer
+from api.params import ACTIVITY_LOG_PARAMETER, activity_log_requested
 from api.serializers import ErrorDetailSerializer
+from api.suggestions.serializers import build_activity_log_map
 from shared.models import (
     NIXPKGS_ISSUE_CODE_REGEX,
     EventType,
@@ -24,8 +28,7 @@ EXPAND_PARAMETER = OpenApiParameter(
     required=False,
     description=(
         "Comma-separated list of fields to inline instead of returning ids. "
-        "Currently only `suggestions` is supported: when included, the "
-        "`suggestions` field contains full suggestion objects instead of ids."
+        "Currently only `suggestions` is supported: when included, the `suggestions` field contains full suggestion objects instead of ids."
     ),
 )
 
@@ -62,27 +65,56 @@ class IssueViewSet(ListModelMixin, RetrieveModelMixin, viewsets.GenericViewSet):
         context = super().get_serializer_context()
         expand = self.request.query_params.get("expand", "")
         expand_fields = {field.strip() for field in expand.split(",") if field.strip()}
-        context["expand_suggestions"] = "suggestions" in expand_fields
+        expand_suggestions = "suggestions" in expand_fields
+        context["expand_suggestions"] = expand_suggestions
+        # Only meaningful when suggestions are inlined; otherwise there is nothing
+        # to attach the activity log to.
+        context["include_activity_log"] = expand_suggestions and activity_log_requested(
+            cast(Request, self.request)
+        )
+        return context
+
+    def _add_activity_log_context(
+        self, issues: list[NixpkgsIssue], context: dict
+    ) -> dict:
+        """Batch the activity log for all suggestions embedded in the given issues."""
+        if context.get("include_activity_log"):
+            suggestion_ids = [
+                suggestion.pk
+                for issue in issues
+                for suggestion in issue.suggestions.all()
+            ]
+            context["activity_logs"] = build_activity_log_map(suggestion_ids)
         return context
 
     @extend_schema(
         operation_id="listIssues",
         description="List all Nixpkgs security issues, sorted by most recently created first.",
-        parameters=[EXPAND_PARAMETER],
+        parameters=[EXPAND_PARAMETER, ACTIVITY_LOG_PARAMETER],
         responses={200: IssueSerializer(many=True)},
     )
     def list(self, request: Request) -> Response:
-        return super().list(request)
+        queryset = self.filter_queryset(self.get_queryset())
+        page = self.paginate_queryset(queryset)
+        issues = page if page is not None else list(queryset)
+        context = self._add_activity_log_context(issues, self.get_serializer_context())
+        serializer = self.get_serializer_class()(issues, many=True, context=context)
+        if page is not None:
+            return self.get_paginated_response(serializer.data)
+        return Response(serializer.data)
 
     @extend_schema(
         operation_id="getIssue",
         description="Get full details of a Nixpkgs security issue.",
-        parameters=[EXPAND_PARAMETER],
+        parameters=[EXPAND_PARAMETER, ACTIVITY_LOG_PARAMETER],
         responses={200: IssueSerializer, 404: ErrorDetailSerializer},
     )
     def retrieve(self, request: Request, code: str) -> Response:
         instance = self.get_object()
-        if self.get_serializer_context()["expand_suggestions"]:
+        context = self.get_serializer_context()
+        if context["expand_suggestions"]:
             for suggestion in instance.suggestions.all():
                 suggestion.ensure_fresh_cache()
-        return Response(self.get_serializer(instance).data)
+        context = self._add_activity_log_context([instance], context)
+        serializer = self.get_serializer_class()(instance, many=False, context=context)
+        return Response(serializer.data)

--- a/src/api/params.py
+++ b/src/api/params.py
@@ -1,0 +1,17 @@
+from drf_spectacular.utils import OpenApiParameter
+from rest_framework.request import Request
+
+ACTIVITY_LOG_PARAMETER = OpenApiParameter(
+    name="activity_log",
+    type=bool,
+    location=OpenApiParameter.QUERY,
+    required=False,
+    description=(
+        "When true, inline each suggestion's activity log in its `activity_log` field instead of requiring a separate request to the activity_log endpoint."
+    ),
+)
+
+
+def activity_log_requested(request: Request) -> bool:
+    """Whether the `activity_log` query param is truthy on this request."""
+    return request.query_params.get("activity_log", "").lower() in ("true", "1", "yes")

--- a/src/api/suggestions/serializers.py
+++ b/src/api/suggestions/serializers.py
@@ -9,7 +9,10 @@ from shared.logs.batches import (
     FoldedPackageEvent,
     FoldedReferenceEvent,
     FoldedStatusEvent,
+    batch_events,
 )
+from shared.logs.events import remove_canceling_events
+from shared.logs.fetchers import fetch_suggestion_events
 from shared.models.linkage import CVEDerivationClusterProposal
 
 
@@ -140,6 +143,22 @@ class SuggestionCategorizedMaintainersSerializer(serializers.Serializer):
     orphan = MaintainerSerializer(many=True)
 
 
+class ActivityLogReferenceSerializer(serializers.Serializer):
+    url = serializers.CharField()
+    name = serializers.CharField(allow_null=True)
+
+
+class ActivityLogEntrySerializer(serializers.Serializer):
+    action = serializers.CharField()
+    timestamp = serializers.DateTimeField()
+    username = serializers.CharField(allow_null=True)
+    status_value = serializers.CharField(allow_null=True, default=None)
+    rejection_reason = serializers.CharField(allow_null=True, default=None)
+    package_names = serializers.ListField(child=serializers.CharField(), default=list)
+    maintainers = MaintainerSerializer(many=True, default=list)
+    references = ActivityLogReferenceSerializer(many=True, default=list)
+
+
 class SuggestionSerializer(serializers.Serializer):
     """Suggestion (proposal linking a CVE to derivations)."""
 
@@ -169,6 +188,11 @@ class SuggestionSerializer(serializers.Serializer):
     metrics = serializers.SerializerMethodField()
     categorized_maintainers = serializers.SerializerMethodField()
     categorized_url_references = serializers.SerializerMethodField()
+
+    # Optional inlined activity log.
+    # Null unless requested via the `activity_log` query param.
+    # Lets the frontend seed the activity-log query as initial data and avoid a separate request per suggestion.
+    activity_log = serializers.SerializerMethodField(allow_null=True)
 
     def _payload(self, obj: CVEDerivationClusterProposal) -> dict:
         return obj.cached.payload
@@ -244,6 +268,18 @@ class SuggestionSerializer(serializers.Serializer):
         data = self._payload(obj)["categorized_url_references"]
         return dict(SuggestionCategorizedUrlReferencesSerializer(data).data)
 
+    @extend_schema_field(ActivityLogEntrySerializer(many=True))
+    def get_activity_log(self, obj: CVEDerivationClusterProposal) -> list | None:
+        if not self.context.get("include_activity_log"):
+            return None
+        activity_logs = self.context.get("activity_logs")
+        if activity_logs is not None and obj.pk in activity_logs:
+            data = activity_logs[obj.pk]
+        else:
+            # Single-object fallback (e.g. retrieve) when no batched map is provided.
+            data = build_activity_log_map([obj.pk]).get(obj.pk, [])
+        return list(ActivityLogEntrySerializer(data, many=True).data)
+
     def to_representation(self, instance: CVEDerivationClusterProposal) -> dict:
         result = super().to_representation(instance)
         if instance.status != CVEDerivationClusterProposal.Status.REJECTED:
@@ -253,25 +289,6 @@ class SuggestionSerializer(serializers.Serializer):
         if not instance.comment:
             result.pop("comment", None)
         return result
-
-
-# Activity log serializers
-
-
-class ActivityLogReferenceSerializer(serializers.Serializer):
-    url = serializers.CharField()
-    name = serializers.CharField(allow_null=True)
-
-
-class ActivityLogEntrySerializer(serializers.Serializer):
-    action = serializers.CharField()
-    timestamp = serializers.DateTimeField()
-    username = serializers.CharField(allow_null=True)
-    status_value = serializers.CharField(allow_null=True, default=None)
-    rejection_reason = serializers.CharField(allow_null=True, default=None)
-    package_names = serializers.ListField(child=serializers.CharField(), default=list)
-    maintainers = MaintainerSerializer(many=True, default=list)
-    references = ActivityLogReferenceSerializer(many=True, default=list)
 
 
 # FIXME(@florentc): Eventually we'll want to:
@@ -301,3 +318,20 @@ def folded_event_to_dict(event: FoldedEventType) -> dict:
     elif isinstance(event, FoldedReferenceEvent):
         base["references"] = [dict(r) for r in event.references]
     return base
+
+
+def build_activity_log_map(suggestion_ids: list[int]) -> dict[int, list[dict]]:
+    """Build the folded, serializable activity log for several suggestions at once."""
+    # FIXME(@florentc): Eventually we'll want to:
+    # - remove cancelling events: at the model level through a proper debouncing implementation
+    # - batch events: at the frontend level as it's presentation-related
+    if not suggestion_ids:
+        return {}
+
+    raw_events_by_id = fetch_suggestion_events(suggestion_ids)
+    result: dict[int, list[dict]] = {}
+    for suggestion_id, raw_events in raw_events_by_id.items():
+        deduplicated = remove_canceling_events(raw_events, sort=True)
+        folded = batch_events(deduplicated)
+        result[suggestion_id] = [folded_event_to_dict(e) for e in folded]
+    return result

--- a/src/api/suggestions/views.py
+++ b/src/api/suggestions/views.py
@@ -1,7 +1,12 @@
+from typing import cast
+
 from django.core.exceptions import ValidationError
 from django.db.models.query import QuerySet
 from django_filters import rest_framework as filters
-from drf_spectacular.utils import extend_schema, extend_schema_serializer
+from drf_spectacular.utils import (
+    extend_schema,
+    extend_schema_serializer,
+)
 from rest_framework import serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import MethodNotAllowed
@@ -13,6 +18,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from api.params import ACTIVITY_LOG_PARAMETER, activity_log_requested
 from api.serializers import ErrorDetailSerializer
 from api.suggestions.serializers import (
     ActivityLogEntrySerializer,
@@ -24,12 +30,9 @@ from api.suggestions.serializers import (
     SuggestionPackageUpdateSerializer,
     SuggestionReferenceUpdateSerializer,
     SuggestionSerializer,
-    folded_event_to_dict,
+    build_activity_log_map,
 )
 from shared.auth import user_can_edit_suggestion
-from shared.logs.batches import batch_events
-from shared.logs.events import remove_canceling_events
-from shared.logs.fetchers import fetch_suggestion_events
 from shared.models import CVEDerivationClusterProposal
 from shared.models.cached import CachedSuggestions
 
@@ -132,23 +135,50 @@ class SuggestionViewSet(ListModelMixin, RetrieveModelMixin, viewsets.GenericView
             .order_by("-updated_at", "-created_at")
         )
 
+    def get_serializer_context(self) -> dict:
+        context = super().get_serializer_context()
+        context["include_activity_log"] = activity_log_requested(
+            cast(Request, self.request)
+        )
+        return context
+
     @extend_schema(
         operation_id="listSuggestions",
         description="List all suggestions (proposals linking CVEs to derivations), paginated and sorted by most recently modified or created first.",
+        parameters=[ACTIVITY_LOG_PARAMETER],
         responses={200: SuggestionSerializer(many=True)},
     )
     def list(self, request: Request) -> Response:
-        return super().list(request)
+        queryset = self.filter_queryset(self.get_queryset())
+        page = self.paginate_queryset(queryset)
+        objects = page if page is not None else list(queryset)
+
+        context = self.get_serializer_context()
+        if context.get("include_activity_log"):
+            # Batch the activity log for the whole page in a fixed number of queries.
+            context["activity_logs"] = build_activity_log_map(
+                [obj.pk for obj in objects]
+            )
+
+        serializer = self.get_serializer_class()(objects, many=True, context=context)
+        if page is not None:
+            return self.get_paginated_response(serializer.data)
+        return Response(serializer.data)
 
     @extend_schema(
         operation_id="getSuggestion",
         description="Get full details of a suggestion (proposal linking CVEs to derivations).",
+        parameters=[ACTIVITY_LOG_PARAMETER],
         responses={200: SuggestionSerializer, 404: ErrorDetailSerializer},
     )
     def retrieve(self, request: Request, pk: int) -> Response:
         instance = self.get_object()
         instance.ensure_fresh_cache()
-        return Response(self.get_serializer(instance).data)
+        context = self.get_serializer_context()
+        if context.get("include_activity_log"):
+            context["activity_logs"] = build_activity_log_map([instance.pk])
+        serializer = self.get_serializer_class()(instance, context=context)
+        return Response(serializer.data)
 
     @extend_schema(
         methods=["get"],
@@ -204,13 +234,7 @@ class SuggestionViewSet(ListModelMixin, RetrieveModelMixin, viewsets.GenericView
     )
     def activity_log(self, request: Request, pk: int) -> Response:
         instance = self.get_object()
-        # FIXME(@florentc): Eventually we'll want to:
-        # - remove cancelling events: at the model level through a proper debouncing implementation
-        # - batch events: at the frontend level as it's presentation-related
-        raw_events = fetch_suggestion_events([instance.pk]).get(instance.pk, [])
-        deduplicated = remove_canceling_events(raw_events, sort=True)
-        folded = batch_events(deduplicated)
-        data = [folded_event_to_dict(e) for e in folded]
+        data = build_activity_log_map([instance.pk]).get(instance.pk, [])
         serializer = ActivityLogEntrySerializer(data, many=True)
         return Response(serializer.data)
 

--- a/src/api/tests/test_suggestion_activity_log.py
+++ b/src/api/tests/test_suggestion_activity_log.py
@@ -1,0 +1,100 @@
+from collections.abc import Callable
+
+from rest_framework.reverse import reverse
+from rest_framework.test import APIClient
+
+from shared.models.issue import NixpkgsIssue
+from shared.models.linkage import CVEDerivationClusterProposal
+
+
+def test_detail_activity_log_null_by_default(
+    cached_suggestion: CVEDerivationClusterProposal,
+    client: APIClient,
+) -> None:
+    response = client.get(
+        reverse(
+            "cvederivationclusterproposal-detail", kwargs={"pk": cached_suggestion.pk}
+        )
+    )
+    assert response.status_code == 200
+    assert response.data["activity_log"] is None
+
+
+def test_detail_activity_log_inlined_when_requested(
+    cached_suggestion: CVEDerivationClusterProposal,
+    client: APIClient,
+) -> None:
+    response = client.get(
+        reverse(
+            "cvederivationclusterproposal-detail", kwargs={"pk": cached_suggestion.pk}
+        ),
+        {"activity_log": "true"},
+    )
+    assert response.status_code == 200
+    activity_log = response.data["activity_log"]
+    assert isinstance(activity_log, list)
+    assert len(activity_log) >= 1
+    entry = activity_log[0]
+    assert set(entry.keys()) >= {"action", "timestamp"}
+    assert any(e["action"] == "create" for e in activity_log)
+
+
+def test_list_activity_log_null_by_default(
+    cached_suggestion: CVEDerivationClusterProposal,
+    client: APIClient,
+) -> None:
+    response = client.get(reverse("cvederivationclusterproposal-list"))
+    assert response.status_code == 200
+    assert response.data["results"][0]["activity_log"] is None
+
+
+def test_list_activity_log_inlined_when_requested(
+    make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
+    client: APIClient,
+) -> None:
+    make_cached_suggestion()
+    make_cached_suggestion()
+    response = client.get(
+        reverse("cvederivationclusterproposal-list"), {"activity_log": "true"}
+    )
+    assert response.status_code == 200
+    for result in response.data["results"]:
+        assert isinstance(result["activity_log"], list)
+        assert len(result["activity_log"]) >= 1
+
+
+def test_issue_expanded_suggestions_inline_activity_log(
+    issue: NixpkgsIssue,
+    client: APIClient,
+) -> None:
+    # Without the param, expanded suggestions carry a null activity log.
+    response = client.get(
+        reverse("nixpkgsissue-detail", kwargs={"code": issue.code}),
+        {"expand": "suggestions"},
+    )
+    assert response.status_code == 200
+    assert response.data["suggestions"][0]["activity_log"] is None
+
+    # With the param, they carry the folded activity log.
+    response = client.get(
+        reverse("nixpkgsissue-detail", kwargs={"code": issue.code}),
+        {"expand": "suggestions", "activity_log": "true"},
+    )
+    assert response.status_code == 200
+    activity_log = response.data["suggestions"][0]["activity_log"]
+    assert isinstance(activity_log, list)
+    assert len(activity_log) >= 1
+
+
+def test_issue_list_expanded_suggestions_inline_activity_log(
+    issue: NixpkgsIssue,
+    client: APIClient,
+) -> None:
+    response = client.get(
+        reverse("nixpkgsissue-list"),
+        {"expand": "suggestions", "activity_log": "true"},
+    )
+    assert response.status_code == 200
+    suggestions = response.data["results"][0]["suggestions"]
+    assert isinstance(suggestions[0]["activity_log"], list)
+    assert len(suggestions[0]["activity_log"]) >= 1


### PR DESCRIPTION
Fetching the activity log was independent from fetching suggestions/issues.

In lists, this meant 1 request per suggestion shown.

This introduces an optional activity_log flag in API to inline it with the suggestions.

The new UI uses it to get rid of inefficient requests.