### PR TITLE
feat: mark external link with the conventional icon in new UI

### DIFF
--- a/frontend/src/components/footer/Footer.tsx
+++ b/frontend/src/components/footer/Footer.tsx
@@ -1,3 +1,4 @@
+import { ExternalLink } from "@/components/ui/ExternalLink";
 import { useServerInfo } from "@/hooks/useServerInfo";
 
 function Revision() {
@@ -11,9 +12,9 @@ function Revision() {
       <p>
         Running revision{" "}
         {production ? (
-          <a href={`https://github.com/NixOS/nix-security-tracker/commit/${revision}`}>
+          <ExternalLink href={`https://github.com/NixOS/nix-security-tracker/commit/${revision}`}>
             {shortRev}
-          </a>
+          </ExternalLink>
         ) : (
           <span>{shortRev} (development)</span>
         )}
@@ -29,10 +30,15 @@ export function Footer() {
     <footer className="bg-nixos-blue box spacious column gap text-white centered">
       <p>
         Nixpkgs security tracker is part of{" "}
-        <a href="https://nixos.org/community/teams/security/">NixOS security infrastructure</a>.
+        <ExternalLink href="https://nixos.org/community/teams/security/">
+          NixOS security infrastructure
+        </ExternalLink>
+        .
       </p>
       <div className="row gap-big">
-        <a href="https://github.com/NixOS/nix-security-tracker">Source code</a>
+        <ExternalLink href="https://github.com/NixOS/nix-security-tracker">
+          Source code
+        </ExternalLink>
         <Revision />
       </div>
     </footer>

--- a/frontend/src/components/issues/Issue.tsx
+++ b/frontend/src/components/issues/Issue.tsx
@@ -10,6 +10,7 @@ import {
   type SuggestionViewMode,
 } from "@/hooks/useSuggestionViewMode";
 import { truncate } from "@/utils/text";
+import { ExternalLink } from "../ui/ExternalLink";
 import { IssueViewToggle } from "./IssueViewToggle";
 
 type Props = {
@@ -49,11 +50,7 @@ export function Issue({
           </div>
           <div className="row gap centered wrap">
             {viewMode === "collapsed" && <Link href={`/ui-v2/issues/${code}`}>Permalink</Link>}
-            {github_issue_url && (
-              <a href={github_issue_url} target="_blank" rel="noreferrer">
-                GitHub issue
-              </a>
-            )}
+            {github_issue_url && <ExternalLink href={github_issue_url}>GitHub issue</ExternalLink>}
             <IssueViewToggle
               value={viewToggleValue}
               onChange={setOwnViewMode}

--- a/frontend/src/components/suggestions/ActivityLog.tsx
+++ b/frontend/src/components/suggestions/ActivityLog.tsx
@@ -16,6 +16,7 @@ import {
   useGetSuggestionActivityLog,
 } from "@/api/generated/endpoints";
 import { type ActivityLogEntry, SuggestionStatusEnum } from "@/api/generated/models";
+import { ExternalLink } from "@/components/ui/ExternalLink";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { Spinner } from "@/components/ui/Spinner";
 import { useTick } from "@/hooks/useTick";
@@ -102,9 +103,7 @@ function entryDescription(entry: ActivityLogEntry) {
       return (
         <span>
           {verb} reference{" "}
-          <a href={refs[0].url} target="_blank" rel="noreferrer">
-            {refs[0].name || refs[0].url.slice(0, 40)}
-          </a>
+          <ExternalLink href={refs[0].url}>{refs[0].name || refs[0].url.slice(0, 40)}</ExternalLink>
         </span>
       );
     }
@@ -116,9 +115,7 @@ function entryDescription(entry: ActivityLogEntry) {
         <ul className="column">
           {refs.map((r) => (
             <li key={r.url}>
-              <a href={r.url} target="_blank" rel="noreferrer">
-                {r.name || r.url}
-              </a>
+              <ExternalLink href={r.url}>{r.name || r.url}</ExternalLink>
             </li>
           ))}
         </ul>

--- a/frontend/src/components/suggestions/Maintainer.tsx
+++ b/frontend/src/components/suggestions/Maintainer.tsx
@@ -1,5 +1,6 @@
 import { UserMinusIcon, UserPlusIcon } from "lucide-preact";
 import type { Maintainer as MaintainerType } from "@/api/generated/models";
+import { ExternalLink } from "@/components/ui/ExternalLink";
 import { useMaintainerMutation } from "@/hooks/useMaintainer";
 
 type Props = {
@@ -33,14 +34,9 @@ export function Maintainer({ maintainer, suggestionId, editable, isIgnored }: Pr
         </button>
       )}
       <div>
-        <a
-          className="bold"
-          href={`https://github.com/${maintainer.github}`}
-          target="_blank"
-          rel="noreferrer"
-        >
+        <ExternalLink className="bold" href={`https://github.com/${maintainer.github}`}>
           @{maintainer.github}
-        </a>
+        </ExternalLink>
         {maintainer.name && <span> {maintainer.name}</span>}
         {maintainer.email && (
           <span>

--- a/frontend/src/components/suggestions/Package.tsx
+++ b/frontend/src/components/suggestions/Package.tsx
@@ -1,5 +1,6 @@
 import { PackageMinusIcon, PackagePlusIcon } from "lucide-preact";
 import type { SuggestionPackage } from "@/api/generated/models";
+import { ExternalLink } from "@/components/ui/ExternalLink";
 import { usePackageMutation } from "@/hooks/usePackage";
 import styles from "./Package.module.css";
 
@@ -55,14 +56,12 @@ export function Package({ attr, pkg, suggestionId, editable, isIgnored }: Props)
                     <span className={styles.channel}>{channel}</span>
                     {info.major_version ? (
                       info.src_position ? (
-                        <a
+                        <ExternalLink
                           className={versionStatusClass(info.status)}
                           href={info.src_position}
-                          target="_blank"
-                          rel="noreferrer"
                         >
                           {info.major_version}
-                        </a>
+                        </ExternalLink>
                       ) : (
                         <span className={versionStatusClass(info.status)}>
                           {info.major_version}
@@ -79,14 +78,12 @@ export function Package({ attr, pkg, suggestionId, editable, isIgnored }: Props)
                       <li key={branch} className="inline-row gap-small">
                         <span className={styles.branch}>{branch}</span>
                         {binfo.src_position ? (
-                          <a
+                          <ExternalLink
                             className={versionStatusClass(binfo.status)}
                             href={binfo.src_position}
-                            target="_blank"
-                            rel="noreferrer"
                           >
                             {binfo.version}
-                          </a>
+                          </ExternalLink>
                         ) : (
                           <span className={versionStatusClass(binfo.status)}>{binfo.version}</span>
                         )}

--- a/frontend/src/components/suggestions/Reference.tsx
+++ b/frontend/src/components/suggestions/Reference.tsx
@@ -1,5 +1,6 @@
 import { LinkIcon, UnlinkIcon } from "lucide-preact";
 import type { SuggestionUrlReference } from "@/api/generated/models";
+import { ExternalLink } from "@/components/ui/ExternalLink";
 import { useReferenceMutation } from "@/hooks/useReference";
 import { ReferenceTag } from "./ReferenceTag";
 
@@ -38,9 +39,7 @@ export function Reference({ reference, suggestionId, editable, isIgnored }: Prop
           {isIgnored ? "Restore" : "Ignore"}
         </button>
       )}
-      <a href={reference.url} target="_blank" rel="noreferrer">
-        {displayedLabel}
-      </a>
+      <ExternalLink href={reference.url}>{displayedLabel}</ExternalLink>
       <ul className="row gap-small">
         {reference.tags.map((tag) => (
           <li key={tag}>

--- a/frontend/src/components/suggestions/Suggestion.tsx
+++ b/frontend/src/components/suggestions/Suggestion.tsx
@@ -1,6 +1,7 @@
 import { useState } from "preact/hooks";
 import { Link } from "wouter-preact";
 import type { Suggestion as SuggestionType } from "@/api/generated/models";
+import { ExternalLink } from "@/components/ui/ExternalLink";
 import { useAuth } from "@/hooks/useAuth";
 import {
   DEFAULT_SUGGESTION_VIEW_MODE,
@@ -54,9 +55,7 @@ export function Suggestion({
             <span data-testid={`suggestion-${id}-status`}>
               <SuggestionStatus status={status} rejectionReason={rejection_reason} iconOnly />
             </span>
-            <a href={nvdUrl} target="_blank" rel="noreferrer">
-              {cve_id}
-            </a>
+            <ExternalLink href={nvdUrl}>{cve_id}</ExternalLink>
             {displayedTitle && <span>{truncate(displayedTitle)}</span>}
           </div>
           <div className="row gap centered">
@@ -96,9 +95,7 @@ export function Suggestion({
         <div className="row gap spread align-start">
           <div className="row gap">
             <Link href={`/ui-v2/suggestions/by-id/${id}`}>Permalink</Link>
-            <a href={nvdUrl} target="_blank" rel="noreferrer">
-              {cve_id}
-            </a>
+            <ExternalLink href={nvdUrl}>{cve_id}</ExternalLink>
             {metrics.length > 0 && <SeverityBadge metrics={metrics} />}
           </div>
           <ActivityLog suggestionId={id} initialActivityLog={suggestion.activity_log} />

--- a/frontend/src/components/ui/ExternalLink.tsx
+++ b/frontend/src/components/ui/ExternalLink.tsx
@@ -1,0 +1,33 @@
+import { ExternalLinkIcon } from "lucide-preact";
+import type { ComponentChild } from "preact";
+
+type ExternalLinkProps = {
+  href: string;
+  children: ComponentChild;
+  className?: string;
+  target?: string;
+  rel?: string;
+  title?: string;
+};
+
+export function ExternalLink({
+  href,
+  children,
+  className,
+  target = "_blank",
+  rel = "noreferrer",
+  title,
+}: ExternalLinkProps) {
+  return (
+    <a
+      href={href}
+      target={target}
+      rel={rel}
+      className={`inline-row centered ${className}`}
+      title={title}
+    >
+      {children}
+      <ExternalLinkIcon size=".9em" style="margin-left: .2em" />
+    </a>
+  );
+}


### PR DESCRIPTION
This addresses #1051 

<img width="1116" height="609" alt="2026-08-25 21-58-48" src="https://github.com/user-attachments/assets/3e43d72f-2c46-4227-89bc-d89b792aa140" />

<img width="535" height="93" alt="2026-08-25 21-58-55" src="https://github.com/user-attachments/assets/df231f82-6574-461a-9056-57749054e215" />

<img width="821" height="109" alt="2026-08-25 21-59-12" src="https://github.com/user-attachments/assets/c1bb1f0b-7813-4874-885d-9e8859494dce" />
