### PR TITLE
feat: add restricted SSH access for obtaining a database dump

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,14 +84,14 @@ To replicate this on a traditional Unix-like system:
 
 ### Resetting the database
 
-In order to start over you need SSH [access to the staging environment](./infra/README.md#adding-ssh-keys).
+In order to get a fully populated database without running ingestion locally, you need [SSH access to a public instance](./infra/README.md#adding-ssh-keys).
 Tools for the following are available in the development shell.
 Delete the database and recreate it, then restore it from a dump, and (just in case the dump is behind the code) run migrations:
 
 ```bash
 dropdb nix-security-tracker
 createdb nix-security-tracker
-ssh root@tracker-staging.security.nixos.org "sudo -u postgres pg_dump --create nix-security-tracker | zstd" | zstdcat | pv | psql
+ssh dump-db@tracker-staging.security.nixos.org | zstdcat | pv | psql
 manage migrate
 ```
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -30,10 +30,12 @@ Similarly, merges on the `production` branch get automatically applied to tracke
 
 ## Adding SSH keys
 
-To request access to the staging or production environment, open a pull request with:
+To request access, open a pull request with:
 
 - Your SSH public key added to a file `<your-github-handle>` in the [`keys`](./keys) directory
-- An addition to `users.users.root.openssh.authorizedKeys.keyFiles` in the respective environment ([staging](./staging.nix), [production](./production.nix), or [both](./common.nix)).
+- In the respective environment ([staging](./staging.nix), [production](./production.nix), or [both](./common.nix)), an addition to:
+  - `custom.dump-db.authorizedKeyFiles` for [obtaining a copy of the database](../CONTRIBUTING.md#resetting-the-database)
+  - `users.users.root.openssh.authorizedKeys.keyFiles` for full access (only needed for operators, all development can be done locally)
 
 ## Secrets
 

--- a/infra/common.nix
+++ b/infra/common.nix
@@ -10,6 +10,7 @@ in
   imports = [
     "${sources.agenix}/modules/age.nix"
     ./keys.nix
+    ./dump-db.nix
   ];
 
   boot = {

--- a/infra/dump-db.nix
+++ b/infra/dump-db.nix
@@ -1,0 +1,39 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib) mkOption types;
+  cfg = config.custom.dump-db;
+in
+{
+  options.custom.dump-db = {
+    authorizedKeyFiles = mkOption {
+      type = types.listOf types.path;
+      default = [ ];
+      description = ''
+        Public key files whose owners can fetch a compressed database dump over SSH.
+        Each key is installed with a forced command and the `restrict` option; no other action is possible with the key.
+      '';
+    };
+  };
+
+  config = {
+    users.users.dump-db = {
+      isSystemUser = true;
+      group = "dump-db";
+      shell = pkgs.bashInteractive;
+      openssh.authorizedKeys.keys =
+        let
+          command = "pg_dump -U postgres --create nix-security-tracker | zstd";
+          # Escaping rules: sshd(8) AUTHORIZED_KEYS FILE FORMAT command="command"
+          ssh-quote = lib.replaceStrings [ ''\'' ''"'' ] [ ''\\'' ''\"'' ];
+          restrict-key = key: ''restrict,command="${ssh-quote command}" ${key}'';
+        in
+        map (file: restrict-key (builtins.readFile file)) cfg.authorizedKeyFiles;
+    };
+    users.groups.dump-db = { };
+  };
+}

--- a/infra/production.nix
+++ b/infra/production.nix
@@ -12,12 +12,6 @@ in
     ./common.nix
   ];
 
-  # FIXME(@fricklerhandwerk): Don't give everyone root.
-  # Wire the users to have the right permissions for doing what they need.
-  users.users.root.openssh.authorizedKeys.keyFiles = with config.custom.keys; [
-
-  ];
-
   networking.hostName = "sectracker";
 
   fileSystems."/" = {

--- a/infra/staging.nix
+++ b/infra/staging.nix
@@ -30,9 +30,7 @@ in
     ];
   };
 
-  # FIXME(@fricklerhandwerk): Don't give everyone root.
-  # Wire the users to have the right permissions for doing what they need.
-  users.users.root.openssh.authorizedKeys.keyFiles = with config.custom.keys; [
+  custom.dump-db.authorizedKeyFiles = with config.custom.keys; [
     florentc
     DarshanCode2005
   ];


### PR DESCRIPTION
The idea behind this change is to allow safely pulling a full database into the development VM (#1045).
Since code running in there is potentially untrusted (e.g. when testing PRs), we don't want that VM to have full access to remote machines.

It also allows us to better separate priviliges for developers and operators, where developers really only need a database and don't have any reason to touch a public instance on the inside.

@DarshanCode2005 @florentc do you have any other use case or reason to connect to staging via SSH?

@devnchill this would enable you to pull a copy from staging as well, when this is merged you can request adding your keys again.