### PR TITLE
chore: unpin arkui dependency as it's been fixed upstream

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "generate-api:local": "orval --project api-local"
   },
   "dependencies": {
-    "@ark-ui/react": "5.37.2",
+    "@ark-ui/react": "^5.37.2",
     "@tanstack/react-query": "^5.60.0",
     "lucide-preact": "^1.17.0",
     "preact": "^10.24.0",


### PR DESCRIPTION
See 5.38.2, 2026-08-17
https://github.com/chakra-ui/ark/releases#release-@ark-ui/react@5.39.0

> Ark now resolves Activity at runtime and falls back to display-none"
> when the active React build does not expose it

