### PR TITLE
feat: refresh matches when new algorithm is available

### DIFF
--- a/nix/configuration.nix
+++ b/nix/configuration.nix
@@ -403,6 +403,7 @@ in
             };
             script = ''
               ${manage.name} backfill_package_clustering
+              ${manage.name} rematch_stale_suggestions
               ${manage.name} regenerate_cached_suggestions
             '';
           };

--- a/src/shared/management/commands/rematch_stale_suggestions.py
+++ b/src/shared/management/commands/rematch_stale_suggestions.py
@@ -1,0 +1,33 @@
+from typing import Any
+
+import pgpubsub
+from django.core.management.base import BaseCommand
+
+from shared.channels import SuggestionRefreshChannel
+from shared.models.linkage import CVEDerivationClusterProposal
+
+
+class Command(BaseCommand):
+    help = "Dispatch a re-match of untriaged suggestions when there's a newer matching algorithm."
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        stale_pks = CVEDerivationClusterProposal.objects.filter(
+            status__in=[
+                CVEDerivationClusterProposal.Status.PENDING,
+                CVEDerivationClusterProposal.Status.ACCEPTED,
+            ],
+            algorithm_version__lt=CVEDerivationClusterProposal.CURRENT_ALGORITHM_VERSION,
+        ).values_list("pk", flat=True)
+
+        if not stale_pks:
+            self.stdout.write("No stale suggestions; nothing to do.")
+            return
+
+        for pk in stale_pks.iterator():
+            pgpubsub.notify(SuggestionRefreshChannel, pk=pk)
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Dispatched {stale_pks.count()} stale suggestion(s) for rematch."
+            )
+        )

--- a/src/shared/tests/test_rematch_stale_suggestions.py
+++ b/src/shared/tests/test_rematch_stale_suggestions.py
@@ -1,0 +1,68 @@
+from collections.abc import Callable, Iterator
+from io import StringIO
+from unittest import mock
+
+import pytest
+from django.core.management import call_command
+
+from shared.channels import SuggestionRefreshChannel
+from shared.models.cve import Container
+from shared.models.linkage import CVEDerivationClusterProposal
+
+
+@pytest.fixture
+def mock_notify() -> Iterator[mock.MagicMock]:
+    with mock.patch(
+        "shared.management.commands.rematch_stale_suggestions.pgpubsub.notify"
+    ) as mocked:
+        yield mocked
+
+
+def test_no_stale_suggestions(db: None, mock_notify: mock.MagicMock) -> None:
+    """Nothing to do when there are no PENDING/ACCEPTED suggestions on an outdated algorithm_version."""
+    out = StringIO()
+    call_command("rematch_stale_suggestions", stdout=out)
+
+    assert "no stale suggestions; nothing to do.\n" == out.getvalue().lower()
+    mock_notify.assert_not_called()
+
+
+def test_dispatches_stale_suggestion(
+    cve: Container,
+    make_suggestion: Callable[..., CVEDerivationClusterProposal],
+    mock_notify: mock.MagicMock,
+) -> None:
+    """A suggestion on an outdated algorithm_version is dispatched for rematch."""
+    # pending stale version
+    pending_suggestion = make_suggestion(container=cve, algorithm_version=0)
+    # acceped stale version
+    accepted_suggestion = make_suggestion(
+        container=cve,
+        algorithm_version=0,
+        status=CVEDerivationClusterProposal.Status.ACCEPTED,
+    )
+    # rejected suggestion
+    make_suggestion(
+        container=cve,
+        algorithm_version=0,
+        status=CVEDerivationClusterProposal.Status.REJECTED,
+    )
+
+    # published suggestion
+    make_suggestion(
+        container=cve,
+        algorithm_version=0,
+        status=CVEDerivationClusterProposal.Status.PUBLISHED,
+    )
+    # suggestion on curreny version
+    make_suggestion(container=cve)
+
+    out = StringIO()
+    call_command("rematch_stale_suggestions", stdout=out)
+
+    expected_calls = [
+        mock.call(SuggestionRefreshChannel, pk=pending_suggestion.pk),
+        mock.call(SuggestionRefreshChannel, pk=accepted_suggestion.pk),
+    ]
+    mock_notify.assert_has_calls(expected_calls, any_order=True)
+    assert mock_notify.call_count == 2


### PR DESCRIPTION
This resolve the [issue](https://github.com/NixOS/nix-security-tracker/issues/1149), 
This allow us to regenerate suggestion rematch on new algorithm update.