### PR TITLE
feat: purge matching training data

### DIFF
--- a/docs/data_ingestion_and_matching.md
+++ b/docs/data_ingestion_and_matching.md
@@ -131,7 +131,8 @@ Reports true positives, false positives, and SNR vs kept derivations and ignored
 Prints one line per CVE by default.
 Use `--quiet` for the summary only, and `--limit N` for a sample.
 
-> [!NOTE]
-> There is no dedicated purge command yet.
-> Imported training data is marked by a fixed training-org UUID and the synthetic `benchmark` channel.
-> For a full corpus, swapping the local database (or development VM disk image) is usually simpler than hand-deleting the graph.
+Remove a previously imported corpus:
+
+```console
+manage purge_matching_training_data
+```

--- a/src/shared/management/commands/purge_matching_training_data.py
+++ b/src/shared/management/commands/purge_matching_training_data.py
@@ -1,0 +1,29 @@
+"""
+Remove imported matching training-data from the local database.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pgtrigger
+from django.core.management.base import BaseCommand
+
+from shared.matching_training_data.purge import purge_training_corpus
+
+
+class Command(BaseCommand):
+    help = (
+        "Delete CVEs imported as matching training data and derivations on the "
+        "synthetic benchmark channel. Does not remove the training organization "
+        "or the benchmark channel/evaluation rows."
+    )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        # Quiet the purge: pgpubsub delete triggers would otherwise enqueue work.
+        with pgtrigger.ignore():
+            totals = purge_training_corpus()
+
+        self.stdout.write(
+            self.style.SUCCESS(f"Purged matching training data: {totals}")
+        )

--- a/src/shared/matching_training_data/__init__.py
+++ b/src/shared/matching_training_data/__init__.py
@@ -1,6 +1,7 @@
 """Matching training-data roundtrip."""
 
 from shared.matching_training_data import serializers
+from shared.matching_training_data.purge import purge_training_corpus
 from shared.matching_training_data.serializers import (
     SCHEMA_VERSION,
     ensure_benchmark_evaluation,
@@ -9,5 +10,6 @@ from shared.matching_training_data.serializers import (
 __all__ = [
     "SCHEMA_VERSION",
     "ensure_benchmark_evaluation",
+    "purge_training_corpus",
     "serializers",
 ]

--- a/src/shared/matching_training_data/purge.py
+++ b/src/shared/matching_training_data/purge.py
@@ -1,0 +1,39 @@
+"""
+Remove locally imported matching training-data from the database.
+"""
+
+from __future__ import annotations
+
+from django.db import transaction
+
+from shared.matching_training_data.serializers import (
+    _TRAINING_ORG_UUID,
+    BENCHMARK_CHANNEL_BRANCH,
+)
+from shared.models.cve import CveRecord
+from shared.models.nix_evaluation import NixDerivation
+
+
+@transaction.atomic
+def purge_training_corpus() -> dict[str, int]:
+    """
+    Delete training-org CVEs and synthetic benchmark-channel derivations.
+
+    CVEs are removed first so proposal links do not block derivation cleanup.
+    The training organization and benchmark channel/evaluation rows are kept.
+    """
+    totals: dict[str, int] = {}
+
+    _, cve_details = CveRecord.objects.filter(
+        assigner__uuid=_TRAINING_ORG_UUID
+    ).delete()
+    for label, count in cve_details.items():
+        totals[label] = totals.get(label, 0) + count
+
+    _, drv_details = NixDerivation.objects.filter(
+        parent_evaluation__channel__channel_branch=BENCHMARK_CHANNEL_BRANCH
+    ).delete()
+    for label, count in drv_details.items():
+        totals[label] = totals.get(label, 0) + count
+
+    return totals

--- a/src/shared/tests/test_matching_training_data_commands.py
+++ b/src/shared/tests/test_matching_training_data_commands.py
@@ -15,7 +15,11 @@ from django.core.management.base import CommandError
 
 from shared.matching_training_data import SCHEMA_VERSION
 from shared.matching_training_data import serializers as mtd
-from shared.matching_training_data.serializers import BENCHMARK_CHANNEL_BRANCH
+from shared.matching_training_data.purge import purge_training_corpus
+from shared.matching_training_data.serializers import (
+    _TRAINING_ORG_UUID,
+    BENCHMARK_CHANNEL_BRANCH,
+)
 from shared.models.cve import Container, CveRecord
 from shared.models.linkage import (
     CVEDerivationClusterProposal,
@@ -366,3 +370,48 @@ def test_import_respects_limit(tmp_path: Path, db: None) -> None:
         ).count()
         == 1
     )
+
+
+def test_purge_removes_imported_training_data(tmp_path: Path, db: None) -> None:
+    record = _sample_api_record("CVE-2026-cmd-purge")
+    (tmp_path / "page-00001.json").write_text(
+        json.dumps([record], indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    call_command(
+        "import_matching_training_data",
+        "--input",
+        str(tmp_path),
+        stdout=StringIO(),
+    )
+    assert CveRecord.objects.filter(cve_id="CVE-2026-cmd-purge").exists()
+    assert NixDerivation.objects.filter(
+        parent_evaluation__channel__channel_branch=BENCHMARK_CHANNEL_BRANCH
+    ).exists()
+
+    call_command("purge_matching_training_data", stdout=StringIO())
+
+    assert not CveRecord.objects.filter(cve_id="CVE-2026-cmd-purge").exists()
+    assert not CVEDerivationClusterProposal.objects.filter(
+        cve__cve_id="CVE-2026-cmd-purge"
+    ).exists()
+    assert not NixDerivation.objects.filter(
+        parent_evaluation__channel__channel_branch=BENCHMARK_CHANNEL_BRANCH
+    ).exists()
+    assert NixChannel.objects.filter(channel_branch=BENCHMARK_CHANNEL_BRANCH).exists()
+
+
+def test_purge_training_corpus_empty(db: None) -> None:
+    assert not CveRecord.objects.filter(assigner__uuid=_TRAINING_ORG_UUID).exists()
+    assert not NixDerivation.objects.filter(
+        parent_evaluation__channel__channel_branch=BENCHMARK_CHANNEL_BRANCH
+    ).exists()
+
+    result = purge_training_corpus()
+
+    assert result == {}
+    assert not CveRecord.objects.filter(assigner__uuid=_TRAINING_ORG_UUID).exists()
+    assert not NixDerivation.objects.filter(
+        parent_evaluation__channel__channel_branch=BENCHMARK_CHANNEL_BRANCH
+    ).exists()


### PR DESCRIPTION
* Add manage purge_matching_training_data to remove locally imported training-org CVEs and synthetic benchmark-channel derivations

* Keeps the training organization and benchmark channel/evaluation for the next import

* Document the command, tests cover purge after import and empty corpus via DB pre/post conditions

Follow-up on https://github.com/NixOS/nix-security-tracker/pull/1244#discussion_r3869429160