### PR TITLE
feat: Section icons (like tabs) in detailed suggestion view in new UI

### DIFF
--- a/frontend/src/components/suggestions/SuggestionDetailedBody.tsx
+++ b/frontend/src/components/suggestions/SuggestionDetailedBody.tsx
@@ -1,3 +1,4 @@
+import { BugIcon, LinkIcon, PackageIcon, UserIcon } from "lucide-preact";
 import type { Suggestion as SuggestionType } from "@/api/generated/models";
 import { AffectedProductsList } from "./AffectedProductsList";
 import { CategorizedMaintainersList } from "./CategorizedMaintainersList";
@@ -31,7 +32,10 @@ export function SuggestionDetailedBody({ suggestion, userCanEdit }: Props) {
         {/* References */}
         {categorized_url_references.original.length > 0 && (
           <div className="rounded border box column gap">
-            <h2 className="text-l bold text-gray">References</h2>
+            <h2 className="text-l bold text-gray row gap-small centered">
+              <LinkIcon size="1em" />
+              References
+            </h2>
             <CategorizedReferencesList
               categorizedReferences={categorized_url_references}
               suggestionId={id}
@@ -43,7 +47,10 @@ export function SuggestionDetailedBody({ suggestion, userCanEdit }: Props) {
         {/* Affected products */}
         {Object.keys(affected_products).length > 0 && (
           <div className="rounded border box column gap">
-            <h2 className="text-l bold text-gray">Affected products</h2>
+            <h2 className="text-l bold text-gray row gap-small centered">
+              <BugIcon size="1em" />
+              Affected products
+            </h2>
             <AffectedProductsList affectedProducts={affected_products} />
           </div>
         )}
@@ -51,7 +58,10 @@ export function SuggestionDetailedBody({ suggestion, userCanEdit }: Props) {
         {/* Packages */}
         {Object.keys(packages).length + Object.keys(ignored_packages).length > 0 && (
           <div className="rounded border box column gap">
-            <h2 className="text-l bold text-gray">Matching in nixpkgs</h2>
+            <h2 className="text-l bold text-gray row gap-small centered">
+              <PackageIcon size="1em" />
+              Matching in nixpkgs
+            </h2>
             <CategorizedPackagesList
               suggestionId={id}
               active={packages}
@@ -64,7 +74,10 @@ export function SuggestionDetailedBody({ suggestion, userCanEdit }: Props) {
         {/* Maintainers */}
         {categorized_maintainers.original.length > 0 && (
           <div className="rounded border box column gap">
-            <h2 className="text-l bold text-gray">Maintainers</h2>
+            <h2 className="text-l bold text-gray row gap-small centered">
+              <UserIcon size="1em" />
+              Maintainers
+            </h2>
             <CategorizedMaintainersList
               suggestionId={id}
               categorizedMaintainers={categorized_maintainers}

--- a/frontend/src/routes/Home.tsx
+++ b/frontend/src/routes/Home.tsx
@@ -30,13 +30,13 @@ const doneFeatures = [
   "Navigation bar",
   "Suggestion lists: optimized batch activity log queries",
   "Suggestions: maintainer add/delete",
+  "Suggestions: section icons (like in tab view)",
 ];
 
 const pendingFeatures = [
   "Notification center",
   "Notification pill (in navbar)",
   "Suggestions: publication and batch publication",
-  "Suggestions: section icons (like in tab view)",
   "Homepage",
   "Help messages (tooltip info about statuses, view modes)",
 ];


### PR DESCRIPTION
Reuses the tab-view icons

<img width="1126" height="953" alt="2026-08-28 18-42-00" src="https://github.com/user-attachments/assets/ca08d61f-fd4e-4d0a-811b-3f8338e0128d" />
