### PR TITLE
chore: Remove stale info from overlay

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -7,24 +7,6 @@ in
   python3 = prev.python3.override {
     packageOverrides = pyfinal: _pyprev: {
       psycopg2 = pyfinal.psycopg;
-      django-rest-knox = pyfinal.buildPythonPackage rec {
-        pname = "django-rest-knox";
-        version = "5.0.4";
-        format = "setuptools";
-
-        src = pyfinal.fetchPypi {
-          pname = "django_rest_knox";
-          inherit version;
-          hash = "sha256-AVXA3z1fZoENmOFtImYD/MoiTBzEwSg/r1abcrcmyTw=";
-        };
-
-        propagatedBuildInputs = with pyfinal; [
-          django
-          djangorestframework
-        ];
-
-        doCheck = false;
-      };
       cpe = pyfinal.buildPythonPackage {
         pname = "cpe";
         version = "1.3.1";

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -18,13 +18,6 @@ in
       };
     };
   };
-  /*
-    FIXME(@fricklerhandwerk): `commitizen` tests fail upstream.
-    Python 3.14 changed argparse's error message format for invalid choices (values are now quoted).
-    This breaks `commitizen`'s snapshot tests.
-    Skip them until commitizen updates its fixtures.
-  */
-  commitizen = prev.commitizen.overrideAttrs { doInstallCheck = false; };
   # go through the motions to make a flake-incompat project use the build
   # inputs we want
   pre-commit-hooks = final.callPackage "${sources.pre-commit-hooks}/nix/run.nix" {


### PR DESCRIPTION
This updates overlay.nix to be a bit more up to date:

- https://github.com/NixOS/nixpkgs/pull/541733 is now merged and we've bumped nixpkgs since then.
- The python argparse and commitizen issue is fixed upstream now.

Closes #1193