### PR TITLE
feat: Homepage in new UI

### DIFF
--- a/frontend/src/routes/Home.tsx
+++ b/frontend/src/routes/Home.tsx
@@ -1,77 +1,147 @@
-import { CircleCheckBigIcon } from "lucide-preact";
-
-const doneFeatures = [
-  "Main framework",
-  "User settings: package subscriptions",
-  "User settings: individual package subscription pages",
-  "User settings: API token management",
-  "Suggestions: individual pages (permalinks)",
-  "Viewing suggestion info: references",
-  "Viewing suggestion info: affected product",
-  "Viewing suggestion info: packages",
-  "Viewing suggestion info: maintainers",
-  "Viewing suggestion info: activity log",
-  "Viewing suggestion info: comments",
-  "Suggestions: comment edit",
-  "Suggestions: reference ignore/restore",
-  "Suggestions: maintainer ignore/restore",
-  "Suggestions: status change (publication excluded)",
-  "Suggestion lists: pagination",
-  "Suggestion lists: per status",
-  "Suggestion lists: by package",
-  "Suggestion lists: draft issue",
-  "Suggestion lists: compact view",
-  "Suggestion lists: collapsed view",
-  "Suggestion lists: tabs view",
-  "Suggestion lists: list and per-suggestion override view modes",
-  "Suggestion lists: visual feedback for 'out of search critera' suggestions",
-  "Published issues list",
-  "Published issues individual page",
-  "Navigation bar",
-  "Suggestion lists: optimized batch activity log queries",
-  "Suggestions: maintainer add/delete",
-  "Suggestions: section icons (like in tab view)",
-  "Suggestions: publication and batch publication",
-];
-
-const pendingFeatures = [
-  "Notification center",
-  "Notification pill (in navbar)",
-  "Homepage",
-  "Help messages (tooltip info about statuses, view modes)",
-];
-
-function DoneItem({ label }: { label: string }) {
-  return (
-    <li className="rounded box compact row gap-small centered bg-green-light">
-      <CircleCheckBigIcon size="1em" />
-      {label}
-    </li>
-  );
-}
-
-function PendingItem({ label }: { label: string }) {
-  return <li className="rounded box compact">{label}</li>;
-}
+import { LayersIcon, MoveDownIcon, UserCogIcon, UserIcon, UserShieldIcon } from "lucide-preact";
+import { Link } from "wouter-preact";
+import { SuggestionStatusIcon } from "@/components/suggestions/SuggestionStatusIcon";
+import { ExternalLink } from "@/components/ui/ExternalLink";
 
 export function Home() {
   return (
     <div className="column gap-big">
-      <h1 className="text-xl bold">Nixpkgs security tracker</h1>
-      <p>
-        New UI under construction. Features are gradually ported and improved from the legacy UI.
-        You may continue to use the <a href="/">legacy UI</a>.
-      </p>
       <div className="column gap">
-        <h2 className="text-l bold">Features</h2>
-        <ul className="column gap-small">
-          {doneFeatures.map((label) => (
-            <DoneItem key={label} label={label} />
-          ))}
-          {pendingFeatures.map((label) => (
-            <PendingItem key={label} label={label} />
-          ))}
-        </ul>
+        <h1 className="text-xl bold">Nixpkgs security tracker</h1>
+        <p>
+          The <strong className="bold">Nixpkgs security tracker</strong> is a web service for
+          managing information on vulnerabilities in software distributed through{" "}
+          <ExternalLink href="https://github.com/NixOS/nixpkgs">Nixpkgs</ExternalLink> and{" "}
+          <ExternalLink href="https://nixos.org/">NixOS</ExternalLink>.
+        </p>
+        <p>
+          It is intended to help with solving the{" "}
+          <ExternalLink href="https://en.wikipedia.org/wiki/Record_linkage">
+            record linkage
+          </ExternalLink>{" "}
+          problem of matching packages in the{" "}
+          <ExternalLink href="https://www.cve.org/">CVE database</ExternalLink> and{" "}
+          <ExternalLink href="https://search.nixos.org/packages">Nixpkgs</ExternalLink>.
+        </p>
+      </div>
+      <h2 className="text-l bold">Workflow</h2>
+      <div className="column centered gap-small">
+        <div className="row gap-big centered">
+          <div className="column centered gap-small">
+            <img src="/static/cveLogo.svg" alt="" aria-hidden="true" style="height: 3em" />
+            <ExternalLink href="https://www.cve.org/ResourcesSupport/Glossary#glossaryRecord">
+              CVE Records
+            </ExternalLink>
+            <MoveDownIcon strokeWidth={0.8} size="2em" />
+          </div>
+          <div className="column centered gap-small">
+            <img src="/static/nixpkgsLogo.svg" alt="" aria-hidden="true" style="height: 3em" />
+            <ExternalLink href="https://search.nixos.org/packages">
+              Nixpkgs derivations
+            </ExternalLink>
+            <MoveDownIcon strokeWidth={0.8} size="2em" />
+          </div>
+        </div>
+        <div className="column centered">
+          <div>Security tracker matching algorithm</div>
+          <div>1 CVE • Several packages</div>
+        </div>
+        <MoveDownIcon strokeWidth={0.8} size="2em" />
+        <Link
+          href="/ui-v2/suggestions?status=pending"
+          className="box rounded border row gap-small centered justify-center"
+          style="min-width: 20em"
+        >
+          <SuggestionStatusIcon status="pending" size="1em" />
+          Untriaged suggestions
+        </Link>
+        <div className="row gap-big">
+          <div className="column gap-small centered" style="width: 15em">
+            <MoveDownIcon strokeWidth={0.8} size="2em" />
+            <div>Team rejects</div>
+            <MoveDownIcon strokeWidth={0.8} size="2em" />
+            <Link
+              href="/ui-v2/suggestions?status=rejected"
+              className="box rounded border row gap-small centered"
+            >
+              <SuggestionStatusIcon status="rejected" size="1em" />
+              Dismissed suggestions
+            </Link>
+            <div>CVEs that already were classified by a human as not affecting Nixpkgs</div>
+          </div>
+          <div className="column gap-small centered" style="width: 15em">
+            <MoveDownIcon strokeWidth={0.8} size="2em" />
+            <div>Team accepts</div>
+            <MoveDownIcon strokeWidth={0.8} size="2em" />
+            <Link
+              href="/ui-v2/suggestions?status=accepted"
+              className="box rounded border row gap-small centered"
+            >
+              <SuggestionStatusIcon status="accepted" size="1em" />
+              Accepted suggestions
+            </Link>
+            <div>May need further refinement</div>
+            <MoveDownIcon strokeWidth={0.8} size="2em" />
+            <div className="column centered">
+              <div>Manual tuning</div>
+            </div>
+            <MoveDownIcon strokeWidth={0.8} size="2em" />
+            <div>Bundle related suggestions</div>
+            <MoveDownIcon strokeWidth={0.8} size="2em" />
+            <Link
+              href="/ui-v2/suggestions?in_issue_draft=true"
+              className="box rounded border row gap-small centered"
+            >
+              <LayersIcon size="1em" />
+              Issue draft
+            </Link>
+            <div>CVEs that users have bundled together for the next GitHub issue</div>
+            <MoveDownIcon strokeWidth={0.8} size="2em" />
+            <Link
+              href="http://localhost:8000/ui-v2/issues"
+              className="box rounded border row gap-small centered"
+            >
+              <SuggestionStatusIcon status="published" size="1em" />
+              Nixpkgs issues
+            </Link>
+            <div>
+              Have a persistent identifier and link to{" "}
+              <ExternalLink href="https://github.com/Nix-Security-WG/sectracker-testing/issues?q=is%3Aissue+state%3Aopen">
+                GitHub issues
+              </ExternalLink>
+              , where maintainers are notified and mitigation is coordinated
+            </div>
+          </div>
+        </div>
+      </div>
+      <h2 className="text-l bold">Contributors and users</h2>
+      <div className="row gap-big wrap justify-center">
+        <div className="column gap centered" style="flex-basis: 15em">
+          <UserShieldIcon size="2em" />
+          <p>
+            <ExternalLink href="https://github.com/NixOS/nixpkgs-committers/">
+              Nixpkgs committers
+            </ExternalLink>{" "}
+            can edit suggestions to help the NixOS security team with triaging.
+          </p>
+        </div>
+        <div className="column gap centered" style="flex-basis: 15em">
+          <UserCogIcon size="2em" />
+          <p>
+            <ExternalLink href="https://github.com/orgs/nixos/teams/nixpkgs-maintainers">
+              Nixpkgs maintainers
+            </ExternalLink>{" "}
+            are encouraged to check their notifications.
+          </p>
+        </div>
+        <div className="column gap centered" style="flex-basis: 15em">
+          <UserIcon size="2em" />
+          <p>
+            If you use NixOS or otherwise rely on software from Nixpkgs,{" "}
+            <Link href="/user/subscriptions">subscribe to notifications</Link> on published
+            vulnerabilities.
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/styles/utility.css
+++ b/frontend/src/styles/utility.css
@@ -328,6 +328,10 @@
   justify-content: flex-end;
 }
 
+.justify-center {
+  justify-content: center;
+}
+
 .spread {
   justify-content: space-between;
 }


### PR DESCRIPTION
This replaces the temporary (almost completed) roadmap in the new UI with an updated version of the legacy homepage.

<img width="822" height="1220" alt="2026-08-31 16-28-58" src="https://github.com/user-attachments/assets/0826a27b-8fc1-44e6-b962-1e135855d6df" />
