### PR TITLE
ci: disable statix repeated keys check

### DIFF
--- a/nix/git-hooks.nix
+++ b/nix/git-hooks.nix
@@ -22,10 +22,17 @@ rec {
       nixfmt.enable = true;
       statix = {
         enable = true;
-        # FIXME(@fricklerhandwerk): `git-hooks.nix` currently renders `statix` command-line arguments incorrectly
-        entry = lib.mkForce "${pkgs.statix}/bin/statix check ${
-          lib.concatMapStringsSep " " (p: "--ignore ${lib.escapeShellArg p}") excludes
-        }";
+        entry =
+          let
+            config = builtins.toFile "statix.toml" ''
+              disabled = ["repeated_keys"]
+            '';
+          in
+          # FIXME(@fricklerhandwerk): `git-hooks.nix` currently renders `statix` command-line arguments incorrectly
+          lib.mkForce
+            "${pkgs.statix}/bin/statix check --config ${config} ${
+              lib.concatMapStringsSep " " (p: "--ignore ${lib.escapeShellArg p}") excludes
+            }";
       };
       deadnix.enable = true;
 


### PR DESCRIPTION
Those are annoying since it requires blowing up the diff when refactoring.

We have enough discipline to keep it tidy without that check.