### PR TITLE
fix: let development VM prompt wait for caching

### DIFF
--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -141,6 +141,19 @@ manage migrate
 
 This is the default Django workflow.
 
+## Changing the caching schema or matching algorithm
+
+For performance reasons, we [cache suggestions](../src/shared/cache_suggestions.py) instead of re-querying all linked items every time.
+The schema for that cache is versioned, and the cache needs to be recreated when the schema changes.
+
+We also allow [rematch untriaged suggestions](../src/shared/listeners/automatic_linkage.py) when there's a new version of the matching algorithm.
+
+Both steps are done automatically in production on deployment, but in the local environment, you have to trigger it yourself in order to avoid unexpectedly long delays when starting up the VM:
+
+```console
+systemctl start nix-security-tracker-caching
+```
+
 ## Resetting the database
 
 Generate a dedicated keypair on your host:

--- a/nix/vm.nix
+++ b/nix/vm.nix
@@ -109,6 +109,7 @@ in
   systemd = {
     services = {
       # Don't start expensive services on boot; trigger them manually when needed.
+      nix-security-tracker-caching.wantedBy = lib.mkForce [ ];
       nix-security-tracker-backfill-package-links.wantedBy = lib.mkForce [ ];
 
       # The Nixpkgs checkout directory is shared by the host, systemd cannot chown it.
@@ -187,7 +188,6 @@ in
       };
 
       "serial-getty@ttyS0" = {
-        wants = [ "nix-security-tracker-server-ready.service" ];
         after = [ "nix-security-tracker-server-ready.service" ];
       };
     };


### PR DESCRIPTION
Otherwise there will be spam on the console while that service still runs.
We could also turn it off, because changing the cache schema between boots will otherwise delay login by a lot.
But then one would have to remember to actually run the recaching.
Changing the schema happens rather rarely anyway.
And ideally we'll get rid of the cache altogether eventually.

This also removes an unnecessary `wants`.