### PR TITLE
fix: give PgBouncer access to the database

### DIFF
--- a/infra/production.nix
+++ b/infra/production.nix
@@ -77,8 +77,6 @@ in
     production = true;
     domain = "tracker.security.nixos.org";
 
-    enablePgbouncer = true;
-
     settings = {
       SYNC_GITHUB_STATE_AT_STARTUP = true;
       GH_ISSUES_PING_MAINTAINERS = true;

--- a/infra/staging.nix
+++ b/infra/staging.nix
@@ -83,8 +83,6 @@ in
     production = true;
     domain = "tracker-staging.security.nixos.org";
 
-    enablePgbouncer = true;
-
     settings = {
       SHOW_DEMO_DISCLAIMER = true;
       SYNC_GITHUB_STATE_AT_STARTUP = true;

--- a/nix/configuration.nix
+++ b/nix/configuration.nix
@@ -25,6 +25,7 @@ let
   # FIXME(@fricklerhandwerk): Use the explicit names everywhere.
   # Maybe implement them as options so they have explicit documentation and can be overridden.
   app = "nix-security-tracker";
+  # FIXME(@fricklerhandwerk): DRY the username, too.
   metrics-group = "${app}-metrics";
 
   pythonEnv = pkgs.python3.withPackages (
@@ -283,6 +284,7 @@ in
           ''
             map-nix-security-tracker nix-security-tracker nix-security-tracker
             map-nix-security-tracker ${exporters.sql.user} nix-security-tracker
+            ${optionalString cfg.enablePgbouncer "map-nix-security-tracker ${config.services.pgbouncer.user} nix-security-tracker"}
             postgres ${exporters.postgres.user} postgres
           '';
         authentication = ''

--- a/nix/configuration.nix
+++ b/nix/configuration.nix
@@ -208,13 +208,17 @@ in
       default = 2;
     };
 
-    enablePgbouncer = mkEnableOption ''
-      PgBouncer connection pooling in front of PostgreSQL for the ASGI web server.
+    enablePgbouncer =
+      (mkEnableOption ''
+        PgBouncer connection pooling in front of PostgreSQL for the ASGI web server.
 
-      When enabled, only `nix-security-tracker-server` connects through
-      PgBouncer. The pgpubsub workers and management commands keep direct database
-      connections, which is required for PostgreSQL LISTEN/NOTIFY.
-    '';
+        When enabled, only `nix-security-tracker-server` connects through
+        PgBouncer. The pgpubsub workers and management commands keep direct database
+        connections, which is required for PostgreSQL LISTEN/NOTIFY.
+      '')
+      // {
+        default = true;
+      };
     enable-exporters = (mkEnableOption "Prometheus metric exporters") // {
       default = true;
     };


### PR DESCRIPTION
In the past it all had only worked because any local user could connect as any database user.
The recent refactoring had narrowed the permissions by making them explicit.