### PR TITLE
fix: failure in crash recovery in suggestion rematching

### DIFF
--- a/nix/configuration.nix
+++ b/nix/configuration.nix
@@ -593,7 +593,7 @@ in
             ];
 
             script = ''
-              ${manage.name} listen --recover \
+              ${manage.name} listen \
                 --processes ${toString cfg.suggestionRefreshProcesses} \
                 --channels \
                   shared.channels.NixEvaluationUpdateChannel \

--- a/src/shared/management/commands/garbage_collect.py
+++ b/src/shared/management/commands/garbage_collect.py
@@ -14,7 +14,9 @@ from django.db.models import (
     When,
 )
 from django.utils import timezone
+from pgpubsub.models import Notification
 
+from shared.channels import NixEvaluationUpdateChannel, SuggestionRefreshChannel
 from shared.models import (  # type: ignore
     CVEDerivationClusterProposalStatusEvent,
     DerivationClusterProposalLinkEvent,
@@ -89,6 +91,8 @@ class Command(BaseCommand):
         self._delete_inactive_channels(batch_size)
         self.stdout.write("\n[6/6] Pruning stale package attrpaths")
         self._prune_stale_package_attrpaths(batch_size)
+        self.stdout.write("\nDeleting stale rematching triggers")
+        self._delete_stale_triggers()
 
         self.stdout.write(self.style.SUCCESS("\nGarbage collection complete."))
 
@@ -277,6 +281,23 @@ class Command(BaseCommand):
             pk_field="channel_branch",
             label="channels",
             batch_size=batch_size,
+        )
+
+    def _delete_stale_triggers(self) -> None:
+        """
+        Reclaim rematching trigger notifications that the listener never drained.
+        Anything older than a day cannot represent live work, since a healthy live listener drains within seconds and the next evaluation would re-emit fresh triggers for anything still relevant.
+        """
+        channels = [SuggestionRefreshChannel, NixEvaluationUpdateChannel]
+        # The producer-side of each channel type records the channel identifier under a different convention.
+        # Both spellings need to be matched to reach all orphaned rows.
+        names = [n for c in channels for n in (c.name(), c.listen_safe_name())]
+        cutoff = timezone.now() - timedelta(hours=24)
+        deleted, _ = Notification.objects.filter(
+            channel__in=names, created_at__lt=cutoff
+        ).delete()
+        self.stdout.write(
+            self.style.SUCCESS(f"Deleted stale rematching triggers: {deleted}")
         )
 
     def _prune_stale_package_attrpaths(self, batch_size: int) -> None:

--- a/src/shared/tests/test_garbage_collect.py
+++ b/src/shared/tests/test_garbage_collect.py
@@ -7,7 +7,13 @@ import pytest
 from django.contrib.auth.models import User
 from django.core.management import call_command
 from django.utils import timezone
+from pgpubsub.models import Notification as PgpubsubNotification
 
+from shared.channels import (
+    ContainerChannel,
+    NixEvaluationUpdateChannel,
+    SuggestionRefreshChannel,
+)
 from shared.management.commands.garbage_collect import DEFAULT_CUTOFF_DAYS, Command
 from shared.models.cve import Container, CveRecord
 from shared.models.linkage import (
@@ -695,3 +701,62 @@ def test_gc_skips_batch_with_protected_derivation(
 
     assert NixDerivation.objects.filter(pk=drv.pk).exists()
     assert "skipped" in out.getvalue()
+
+
+def make_trigger_notification(
+    channel_name: str, age: timedelta
+) -> PgpubsubNotification:
+    n = PgpubsubNotification.objects.create(channel=channel_name, payload={})
+    PgpubsubNotification.objects.filter(pk=n.pk).update(created_at=timezone.now() - age)
+    n.refresh_from_db()
+    return n
+
+
+@pytest.mark.parametrize(
+    "channel_name",
+    [
+        SuggestionRefreshChannel.name(),
+        SuggestionRefreshChannel.listen_safe_name(),
+        NixEvaluationUpdateChannel.name(),
+        NixEvaluationUpdateChannel.listen_safe_name(),
+    ],
+)
+@pytest.mark.django_db
+def test_gc_deletes_stale_rematching_notifications(channel_name: str) -> None:
+    """
+    `pgpubsub` records the channel identifier under two conventions depending on how the notification was emitted.
+    Both conventions must be covered so that orphans left by any producer can be reclaimed.
+    """
+    make_trigger_notification(channel_name, age=timedelta(hours=25))
+
+    call_command("garbage_collect", stdout=StringIO())
+
+    assert not PgpubsubNotification.objects.filter(channel=channel_name).exists()
+
+
+@pytest.mark.django_db
+def test_gc_keeps_recent_rematching_notifications() -> None:
+    """
+    The threshold matches the interval at which fresh notifications are emitted by the evaluator.
+    Anything younger might still be processed by the live listener.
+    """
+    make_trigger_notification(SuggestionRefreshChannel.name(), age=timedelta(hours=23))
+
+    call_command("garbage_collect", stdout=StringIO())
+
+    assert PgpubsubNotification.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_gc_keeps_notifications_on_other_channels() -> None:
+    """
+    We only garbage-collect trigger channels that leave garbage.
+    Unrelated channels stay untouched.
+    """
+    make_trigger_notification(
+        ContainerChannel.listen_safe_name(), age=timedelta(days=30)
+    )
+
+    call_command("garbage_collect", stdout=StringIO())
+
+    assert PgpubsubNotification.objects.count() == 1


### PR DESCRIPTION
This one was really hard to figure out, because the logs weren't very informative and that particular process wasn't leaving a lot of traces in the database...

Due to how `pgpubsub` works, a listener would lock all notifications in the recovery phase on startup.
If it crashes, all notifications are put back to the queue, and only picked up again on next startup.
This would result in old notifications never getting processed.

In our case, rematching only needs to get done against the latest evaluation.
Therefore we can skip recovery entirely, since a new evaluation should appear every day anyway.
Then we only need garbage-collect the dangling notifications from crashed listeners once in a while.

Closes #618 (finally)