### PR TITLE
feat: API rate limiting

### DIFF
--- a/src/api/tests/conftest.py
+++ b/src/api/tests/conftest.py
@@ -3,8 +3,14 @@ from collections.abc import Callable
 import pytest
 from django.contrib.auth.models import User
 from rest_framework.test import APIClient
+from rest_framework.views import APIView
 
 pytest_plugins = ["shared.tests.conftest"]
+
+
+@pytest.fixture(autouse=True)
+def disable_api_throttling(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(APIView, "throttle_classes", [])
 
 
 @pytest.fixture

--- a/src/api/tests/test_throttling.py
+++ b/src/api/tests/test_throttling.py
@@ -1,0 +1,79 @@
+from collections.abc import Callable
+
+import pytest
+from django.contrib.auth.models import User
+from django.core.cache import cache
+from django.test import override_settings
+from knox.models import AuthToken
+from rest_framework import status
+from rest_framework.test import APIClient
+from rest_framework.views import APIView
+
+from api.throttling import APIRateThrottle
+
+PROBE_URL = "/api/v1/server-info"
+
+
+@pytest.fixture(autouse=True)
+def enable_api_throttling(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        APIView,
+        "throttle_classes",
+        [APIRateThrottle],
+    )
+
+
+@pytest.fixture(autouse=True)
+def clear_throttle_cache() -> None:
+    cache.clear()
+
+
+@pytest.mark.django_db
+@override_settings(API_THROTTLE_ANONYMOUS="1/min")
+def test_anonymous_requests_are_throttled() -> None:
+    client = APIClient()
+    assert client.get(PROBE_URL).status_code == status.HTTP_200_OK
+    assert client.get(PROBE_URL).status_code == status.HTTP_429_TOO_MANY_REQUESTS
+
+
+@pytest.mark.django_db
+@override_settings(API_THROTTLE_AUTHENTICATED="1/min")
+def test_authenticated_session_requests_are_throttled(user: User) -> None:
+    client = APIClient()
+    client.force_login(user)
+    assert client.get(PROBE_URL).status_code == status.HTTP_200_OK
+    assert client.get(PROBE_URL).status_code == status.HTTP_429_TOO_MANY_REQUESTS
+
+
+@pytest.mark.django_db
+@override_settings(
+    API_THROTTLE_AUTHENTICATED="1/min",
+    API_THROTTLE_SECURITY_TEAM="2/min",
+)
+def test_security_team_has_its_own_rate(staff: User) -> None:
+    client = APIClient()
+    client.force_login(staff)
+    assert client.get(PROBE_URL).status_code == status.HTTP_200_OK
+    assert client.get(PROBE_URL).status_code == status.HTTP_200_OK
+    assert client.get(PROBE_URL).status_code == status.HTTP_429_TOO_MANY_REQUESTS
+
+
+@pytest.mark.django_db
+@override_settings(API_THROTTLE_AUTHENTICATED="1/min")
+def test_token_and_session_requests_use_independent_buckets(
+    user: User,
+    make_token: Callable[..., tuple[AuthToken, str]],
+) -> None:
+    _, raw_token = make_token(user)
+
+    session_client = APIClient()
+    session_client.force_login(user)
+    token_client = APIClient()
+    token_client.credentials(HTTP_AUTHORIZATION=f"Bearer {raw_token}")
+
+    assert session_client.get(PROBE_URL).status_code == status.HTTP_200_OK
+    assert token_client.get(PROBE_URL).status_code == status.HTTP_200_OK
+    assert (
+        session_client.get(PROBE_URL).status_code == status.HTTP_429_TOO_MANY_REQUESTS
+    )
+    assert token_client.get(PROBE_URL).status_code == status.HTTP_429_TOO_MANY_REQUESTS

--- a/src/api/throttling.py
+++ b/src/api/throttling.py
@@ -1,0 +1,31 @@
+from django.conf import settings
+from rest_framework.request import Request
+from rest_framework.throttling import SimpleRateThrottle
+
+from shared.auth import isadmin
+
+
+class APIRateThrottle(SimpleRateThrottle):
+    scope = "api"
+
+    def allow_request(self, request: Request, view: object) -> bool:
+        self.rate = self.get_rate(request)
+        self.num_requests, self.duration = self.parse_rate(self.rate)
+        return super().allow_request(request, view)
+
+    def get_rate(self, request: Request | None = None) -> str:
+        if request is None:
+            return settings.API_THROTTLE_AUTHENTICATED
+        if not request.user.is_authenticated:
+            return settings.API_THROTTLE_ANONYMOUS
+        if isadmin(request.user):
+            return settings.API_THROTTLE_SECURITY_TEAM
+        return settings.API_THROTTLE_AUTHENTICATED
+
+    def get_cache_key(self, request: Request, view: object) -> str:
+        if request.user.is_authenticated:
+            auth_method = "token" if request.auth is not None else "session"
+            ident = f"{request.user.pk}:{auth_method}"
+        else:
+            ident = self.get_ident(request)
+        return self.cache_format % {"scope": self.scope, "ident": ident}

--- a/src/project/settings.py
+++ b/src/project/settings.py
@@ -258,6 +258,9 @@ class Settings(BaseSettings):
             """,
             default=100 * 64 // 2,
         )
+        API_THROTTLE_ANONYMOUS: str = "30/min"
+        API_THROTTLE_AUTHENTICATED: str = "120/min"
+        API_THROTTLE_SECURITY_TEAM: str = "2000/min"
 
         @model_validator(mode="after")
         def default_server_email(self) -> Self:
@@ -535,6 +538,7 @@ REST_FRAMEWORK = {
         "knox.auth.TokenAuthentication",
         "rest_framework.authentication.SessionAuthentication",
     ],
+    "DEFAULT_THROTTLE_CLASSES": ["api.throttling.APIRateThrottle"],
 }
 
 # drf-spectacular (openapi generation) settings

--- a/src/webview/tests/ui_v2/conftest.py
+++ b/src/webview/tests/ui_v2/conftest.py
@@ -1,6 +1,12 @@
 from typing import Any
 
 import pytest
+from rest_framework.views import APIView
+
+
+@pytest.fixture(autouse=True)
+def disable_api_throttling(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(APIView, "throttle_classes", [])
 
 
 @pytest.fixture


### PR DESCRIPTION
Implements #1220

This introduces throttling for API requests:

30/min for anonymous users
120/min for authenticated users
2000/min for security team (they are our trusted users and will likely need the API to script bulk operations)

There are 2 different cache keys for standalone API usage (authentication through bearer token) and UI API usage (cookie) as mentioned in the issue. Both have the same limits (so for authenticated users 120 requests per minute on the UI + 120 requests per minutes through using their API key)  but we could introduce different limits.

I have no idea if these values are realistic. I guess you'll have a better gut feeling @Erethon @fricklerhandwerk 

For the new UI, I'd say 30/min is the comfort zone, a.k.a. 1 click every 2 second. The UI is normally well optimized and a click usually generates 1 request only, at most 2. However I've see a bug occasionnally on staging (that I can't reproduce accurately) where the user info and server info are fetched at every click (so it'd be 3 requests per click). Even considering that, 30/min for anonymous users seems decent, especially considering query caching (a given info is considered fresh for 30 seconds see `staleTime` in the frontend).


<img width="678" height="163" alt="2026-09-10 15-40-49" src="https://github.com/user-attachments/assets/af7ec09c-c484-45fd-821d-ffa4ad80c31f" />
<img width="435" height="311" alt="2026-09-10 15-39-57" src="https://github.com/user-attachments/assets/7b8da00d-6e5c-4a21-910f-71818b9b4463" />