### PR TITLE
fix: actually process rematching triggers

### DIFF
--- a/nix/django-pgpubsub-fix-notify.patch
+++ b/nix/django-pgpubsub-fix-notify.patch
@@ -1,0 +1,20 @@
+diff --git a/pgpubsub/notify.py b/pgpubsub/notify.py
+index 186495a..96b55ad 100644
+--- a/pgpubsub/notify.py
++++ b/pgpubsub/notify.py
+@@ -1,3 +1,4 @@
++import json
+ import logging
+ from typing import Type, Union
+ 
+@@ -23,8 +24,8 @@ def notify(channel: Union[Type[Channel], str], **kwargs):
+         if channel_cls.lock_notifications:
+             from pgpubsub.models import Notification
+             Notification.objects.create(
+-                channel=name,
+-                payload=serialized,
++                channel=channel_cls.listen_safe_name(),
++                payload=json.loads(serialized),
+             )
+     return serialized
+ 

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -7,6 +7,11 @@ in
   python3 = prev.python3.override {
     packageOverrides = pyfinal: _pyprev: {
       psycopg2 = pyfinal.psycopg;
+      # FIXME(@fricklerhandwerk): remove once upstream fix is merged into django-pgpubsub
+      # https://github.com/PaulGilmartin/django-pgpubsub/pull/89
+      django-pgpubsub = _pyprev.django-pgpubsub.overridePythonAttrs (old: {
+        patches = (old.patches or [ ]) ++ [ ../nix/django-pgpubsub-fix-notify.patch ];
+      });
       cpe = pyfinal.buildPythonPackage {
         pname = "cpe";
         version = "1.3.1";

--- a/src/api/suggestions/views.py
+++ b/src/api/suggestions/views.py
@@ -133,8 +133,7 @@ class SuggestionViewSet(ListModelMixin, RetrieveModelMixin, viewsets.GenericView
 
         # Only suggestions with fresh cache
         return (
-            CVEDerivationClusterProposal.objects.target_proposals()
-            .filter(
+            CVEDerivationClusterProposal.objects.filter(
                 cached__isnull=False,
                 cached__schema_version=CachedSuggestions.CURRENT_SCHEMA_VERSION,
             )

--- a/src/api/tests/test_suggestion_list.py
+++ b/src/api/tests/test_suggestion_list.py
@@ -106,10 +106,12 @@ def test_suggestion_list_excludes_suggestions_without_fresh_cache(
     assert uncached.pk not in ids
 
 
-def test_suggestion_list_excludes_outdated_algorithm_version_pending_suggestions(
+def test_suggestion_list_includes_outdated_algorithm_version_pending_suggestions(
     make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
 ) -> None:
-    """Pending suggestions from an outdated matching algorithm version are excluded."""
+    """
+    Pending suggestions from any algorithm version are included in the list.
+    """
     client = APIClient()
     outdated = make_cached_suggestion(
         status=CVEDerivationClusterProposal.Status.PENDING,
@@ -120,7 +122,7 @@ def test_suggestion_list_excludes_outdated_algorithm_version_pending_suggestions
     response = client.get(url())
     assert response.status_code == 200
     ids = [item["id"] for item in response.data["results"]]
-    assert outdated.pk not in ids
+    assert outdated.pk in ids
     assert current.pk in ids
 
 

--- a/src/webview/suggestions/views/lists.py
+++ b/src/webview/suggestions/views/lists.py
@@ -58,10 +58,8 @@ class SuggestionListView(ListView, ABC):
         if self.package_filter is not None:
             query_filters &= Q(cached__payload__packages__has_key=self.package_filter)
 
-        qs = CVEDerivationClusterProposal.objects.target_proposals()
-
         return (
-            qs.select_related("cached")
+            CVEDerivationClusterProposal.objects.select_related("cached")
             .prefetch_related("cve__container__references__tags")
             .filter(query_filters)
             .order_by("-updated_at", "-created_at")

--- a/src/webview/tests/test_algorithm_version_filter.py
+++ b/src/webview/tests/test_algorithm_version_filter.py
@@ -12,12 +12,14 @@ _OUTDATED_VERSION: int = (
 )
 
 
-def test_untriaged_list_shows_active_version_only(
+def test_untriaged_list_shows_all_algorithm_versions(
     live_server: LiveServer,
     as_staff: Page,
     make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
 ) -> None:
-    """Only current-version proposals appear on the untriaged (pending) list."""
+    """
+    Pending proposals from any algorithm version appear on the untriaged list.
+    """
 
     current_proposal = make_cached_suggestion(
         status=CVEDerivationClusterProposal.Status.PENDING,
@@ -31,16 +33,18 @@ def test_untriaged_list_shows_active_version_only(
     as_staff.goto(live_server.url + reverse("webview:suggestion:untriaged_suggestions"))
 
     expect(as_staff.locator(f"#suggestion-{current_proposal.pk}")).to_be_visible()
-    expect(as_staff.locator(f"#suggestion-{outdated_proposal.pk}")).not_to_be_visible()
+    expect(as_staff.locator(f"#suggestion-{outdated_proposal.pk}")).to_be_visible()
 
 
-def test_list_by_package_shows_target_propospals_only(
+def test_list_by_package_shows_all_algorithm_versions(
     live_server: LiveServer,
     as_staff: Page,
     make_cached_suggestion: Callable[..., CVEDerivationClusterProposal],
     drv: NixDerivation,
 ) -> None:
-    """Only current-version proposals appear on the untriaged (pending) list."""
+    """
+    Proposals from any algorithm version appear in the package-filtered list.
+    """
     current_proposal = make_cached_suggestion(
         status=CVEDerivationClusterProposal.Status.PENDING,
     )
@@ -61,7 +65,7 @@ def test_list_by_package_shows_target_propospals_only(
 
     expect(as_staff.locator(f"#suggestion-{current_proposal.pk}")).to_be_visible()
     expect(as_staff.locator(f"#suggestion-{accepted_outdated.pk}")).to_be_visible()
-    expect(as_staff.locator(f"#suggestion-{outdated_proposal.pk}")).not_to_be_visible()
+    expect(as_staff.locator(f"#suggestion-{outdated_proposal.pk}")).to_be_visible()
 
 
 def test_accepted_and_dismissed_lists_show_all_versions(


### PR DESCRIPTION
This was a one of the most fun debugging marathons I ever had, because the failure was absolutely silent. It ended up being a [bug in `pgpubsub`](https://github.com/PaulGilmartin/django-pgpubsub/issues/83), the library we're using for dispatching background jobs. I only found there was even an issue for it when I found the problem myself, because it had been obscured by two other subtle problems that broke that pipeline:
- https://github.com/NixOS/nix-security-tracker/pull/1309
- https://github.com/NixOS/nix-security-tracker/pull/1310

I sent a patch to upstream: https://github.com/PaulGilmartin/django-pgpubsub/pull/89
Until then, we patch it locally, so it finally...

closes #618 for real now